### PR TITLE
Added option 'slack_highlight_words' that when turned on will highlig…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Development
 
 Dependencies
 ------------
-  * WeeChat 1.3+ http://weechat.org/ 
+  * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
 
 Setup
@@ -101,7 +101,7 @@ If you don't want to store your API token in plaintext you can use the secure fe
 ```
 
 ##### Optional: If you would like to connect to multiple groups, use the above command with multiple tokens separated by commas. (NO SPACES)
-    
+
 ```
 /set plugins.var.python.slack_extension.slack_api_token [token1],[token2],[token3]
 ```
@@ -175,6 +175,11 @@ Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. wh
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
 ```
 
+Turn on highlighting of slack higlight words (@channel, @everyone):
+```
+/set plugins.var.python.slack_extension.slack_highlight_words 1
+```
+
 Set all read markers to a specific time:
 ```
 /slack setallreadmarkers (time in epoch)
@@ -211,4 +216,4 @@ wee-slack is provided without any warranty whatsoever, but you are welcome to as
 
 
 
-    
+

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -617,6 +617,10 @@ class Channel(object):
             set_read_marker = True
         elif message.find(self.server.nick.encode('utf-8')) > -1:
             tags = "notify_highlight"
+        elif slack_highlight_words and message.find("!channel".encode('utf-8')) > -1:
+            tags = "notify_highlight"
+        elif slack_highlight_words and message.find("!everyone".encode('utf-8')) > -1:
+            tags = "notify_highlight"
         elif user != self.server.nick and self.name in self.server.users:
             tags = "notify_private,notify_message"
         elif self.muted:
@@ -2116,6 +2120,7 @@ def config_changed_cb(data, option, value):
         slack_api_token = w.string_eval_expression(slack_api_token, {}, {}, {})
 
     distracting_channels = [x.strip() for x in w.config_get_plugin("distracting_channels").split(',')]
+    slack_highlight_words = w.config_get_plugin("slack_highlight_words") == "1"
     colorize_nicks = w.config_get_plugin('colorize_nicks') == "1"
     debug_mode = w.config_get_plugin("debug_mode").lower()
     if debug_mode != '' and debug_mode != 'false':
@@ -2177,6 +2182,8 @@ if __name__ == "__main__":
                 w.config_set_plugin('slack_api_token', "INSERT VALID KEY HERE!")
             if not w.config_get_plugin('distracting_channels'):
                 w.config_set_plugin('distracting_channels', "")
+            if not w.config_get_plugin('slack_highlight_words'):
+                w.config_set_plugin('slack_highlight_words', "0")
             if not w.config_get_plugin('debug_mode'):
                 w.config_set_plugin('debug_mode', "")
             if not w.config_get_plugin('colorize_nicks'):


### PR DESCRIPTION
…ht messages containing @channel and @everyone.

This setting defaults to off, however when it's on allows weechat to highlight any messages containing @channel or @everyone. This way the user can use something like highmon to capture these messages or a notification plugin to get desktop notifications.
