### PR TITLE
Fix /me handling for sent and received messages

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -69,6 +69,8 @@ class FakeWeechat():
         return "testuser"
     def buffer_new(*args):
         return "0x8a8a8a8b"
+    def prefix(self, type):
+        return ""
     def __getattr__(self, name):
         def method(*args):
             pass


### PR DESCRIPTION
- Received messages are now properly detected whether they use _
wrapping or the me_message subtype
- Sent messages are now properly rendered as actions in the buffer
- Message replies in general are now handled by process_message(), and
thus should have formatting consistent with normal messages

Signed-off-by: Ben Kelly <bk@ancilla.ca>