### PR TITLE
Include - in the allowable nick characters

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -580,11 +580,11 @@ class Channel(object):
     def linkify_text(self, message):
         message = message.split(' ')
         for item in enumerate(message):
-            targets = re.match('.*([@#])([\w.]+\w)(\W*)', item[1])
+            targets = re.match('([@#])([\w.-]+)(\W*)', item[1])
             if targets and targets.groups()[0] == '@':
                 named = targets.groups()
                 if named[1] in ["group", "channel", "here"]:
-                    message[item[0]] = "<!{}>".format(named[1])
+                    message[item[0]] = "<!{}>{}".format(named[1], named[2])
                 if self.server.users.find(named[1]):
                     message[item[0]] = "<@{}>{}".format(self.server.users.find(named[1]).identifier, named[2])
             if targets and targets.groups()[0] == '#':


### PR DESCRIPTION
I was having a problem where, on a net with users "foo" and "foo-bar",
attempting to @foo-bar would send @foo- instead. Turns out it thought -
terminated the nick.

also, it turns out nicks can end with - and probably . as well.

Signed-off-by: Ben Kelly <bk@ancilla.ca>