### PR TITLE
Full precision Slack timestamp handling

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -680,7 +680,6 @@ class Channel(object):
         writes output (message) to a buffer (channel)
         """
         set_read_marker = False
-        w.prnt("", time)
         time_int, time_id = time.split(".", 2)
         time_int = int(time_int)
         tags = "nick_" + user


### PR DESCRIPTION
Slack sends a timestamp in messages as "ts", which looks like "1473363728.000174".
The bit before the "." is an epoch timestamp and the bit after is a unique ID (not fractional seconds as I used to think).

If two messages are sent during the same second (common), the only way for me to add an emoji reaction is to work my way back up the list to find the right message, but weechat's resolution is only to the second.

Today I noticed that the hdata structure for line_data stores both the 'message time' and 'printed time' - the latter seems useless so I am going to store the .0000174 bit there. I'm worried something might use it, but so far i haven't seen evidence of that.

This allows me to search the backlog of a channel for the full time(string?) as opposed to the sloppy method. We need this resolution to make threads work well, mostly for performance.