### PR TITLE
Update token link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ weechat
 ```
 /set plugins.var.python.slack_extension.slack_api_token [YOUR_SLACK_TOKEN]
 ```
-^^ (find this at https://api.slack.com/web behind the "Generate test tokens" button)
+^^ (find this at https://api.slack.com/custom-integrations/legacy-tokens using the "Request token" button)
 
 If you don't want to store your API token in plaintext you can use the secure features of weechat:
 


### PR DESCRIPTION
The previous page only links to the new style application tokens, which do not work.