### PR TITLE
channels: format fullname with unicode

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -551,7 +551,7 @@ class Channel(object):
                 dbg("DEBUG: {} {} {}".format(self.identifier, self.name, e))
 
     def fullname(self):
-        return "{}.{}".format(self.server.server_buffer_name, self.name)
+        return u"{}.{}".format(self.server.server_buffer_name, self.name)
 
     def has_user(self, name):
         return name in self.members


### PR DESCRIPTION
Fixes the following traceback on connections:

```
Traceback (most recent call last):
  File "wee_slack.py", line 2316, in url_processor_cb
    servers.find(data["token"]).connected_to_slack(my_json)
  File "wee_slack.py", line 266, in connected_to_slack
    self.create_slack_mappings(login_data)
  File "wee_slack.py", line 340, in create_slack_mappings
    self.add_channel(Channel(self, **item))
  File "wee_slack.py", line 190, in add_channel
    self.channels.append(channel, channel.get_aliases())
  File "wee_slack.py", line 472, in get_aliases
    aliases = [self.fullname(), self.name, self.identifier,
               self.name[1:], ]
  File "wee_slack.py", line 554, in fullname
    return "{}.{}".format(self.server.server_buffer_name, self.name)
UnicodeEncodeError: 'ascii' codec can't encode characters in position
                    1-4: ordinal not in range(128)
```