### PR TITLE
Make tests pass on Python 3

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -18,13 +18,13 @@ class FakeWeechat():
     WEECHAT_RC_OK = True
 
     def __init__(self):
-        print "INITIALIZE FAKE WEECHAT"
+        print("INITIALIZE FAKE WEECHAT")
     def prnt(*args):
         output = "("
         for arg in args:
             if arg != None:
                 output += "{}, ".format(arg)
-        print "w.prnt {}".format(output)
+        print("w.prnt {}".format(output))
     def hdata_get(*args):
         return "0x000001"
     def hdata_pointer(*args):
@@ -36,14 +36,15 @@ class FakeWeechat():
 
     def __getattr__(self, name):
         def method(*args):
-            print "called {}".format(name)
+            print("called {}".format(name))
             if args:
-                print "\twith args: {}".format(args)
+                print("\twith args: {}".format(args))
         return method
 
 @pytest.fixture
 def fake_weechat():
     wee_slack.w = FakeWeechat()
+    wee_slack.config = wee_slack.PluginConfig()
     pass
 
 
@@ -73,17 +74,17 @@ def myservers(server):
 @pytest.fixture
 def channel(monkeypatch, server):
     def mock_buffer_prnt(*args):
-        print "called buffer_prnt\n\twith args: {}".format(args)
+        print("called buffer_prnt\n\twith args: {}".format(args))
         return
     def mock_do_nothing(*args):
-        print args
+        print(args)
         return True
     monkeypatch.setattr(Channel, 'create_buffer', mock_do_nothing)
     monkeypatch.setattr(Channel, 'attach_buffer', mock_do_nothing)
     monkeypatch.setattr(Channel, 'set_topic', mock_do_nothing)
     monkeypatch.setattr(Channel, 'set_topic', mock_do_nothing)
     monkeypatch.setattr(Channel, 'buffer_prnt', mock_buffer_prnt)
-    mychannel = Channel(server, '#testchan', 'C2147483705', True, last_read=0, prepend_name="", members=[], topic="")
+    mychannel = Channel(server, name='#testchan', id='C2147483705')
     return mychannel
 
 @pytest.fixture

--- a/_pytest/test_process_message.py
+++ b/_pytest/test_process_message.py
@@ -20,7 +20,7 @@ def test_process_message(slack_debug, monkeypatch, myservers, mychannels, myuser
 
 #    def mock_buffer_prnt_changed(*args):
 #        called['buffer_prnt_changed'] += 1
-#        print args
+#        print(args)
 #    monkeypatch.setattr(wee_slack.Channel, 'buffer_prnt_changed', mock_buffer_prnt_changed)
 
 
@@ -31,8 +31,8 @@ def test_process_message(slack_debug, monkeypatch, myservers, mychannels, myuser
     messages.append( json.loads(open('_pytest/data/message-deleted.json', 'r').read()) )
     for m in messages:
         wee_slack.process_message(m)
-    print "---"
-    print called
-    print "---"
+    print("---")
+    print(called)
+    print("---")
 #    assert called['buffer_prnt'] == 2
 #    assert called['buffer_prnt_changed'] == 1

--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -41,6 +41,6 @@ def test_unfurl_refs(myservers, mychannels, myusers, case):
     slack.users = myusers
     slack.message_cache = {}
     slack.servers[0].users = myusers
-    print mychannels[0].identifier
+    print(mychannels[0].identifier)
 
     assert slack.unfurl_refs(case['input'], ignore_alt_text=case.get('ignore_alt_text', False)) == case['output']

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -693,7 +693,7 @@ class Channel(object):
             tags += ",notify_private,notify_message,log1,irc_privmsg"
         elif self.muted:
             tags += ",no_highlight,notify_none,logger_backlog_end"
-        elif user in [x.strip() for x in w.prefix("join"), w.prefix("quit")]:
+        elif user in [x.strip() for x in (w.prefix("join"), w.prefix("quit"))]:
             tags += ",irc_smart_filter"
         else:
             tags += ",notify_message,log1,irc_privmsg"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -7,7 +7,7 @@ import time
 import json
 import os
 import pickle
-import sha
+import hashlib
 import re
 import urllib
 import HTMLParser
@@ -2297,7 +2297,7 @@ big_data = {}
 def url_processor_cb(data, command, return_code, out, err):
     global big_data
     data = pickle.loads(data)
-    identifier = sha.sha("{}{}".format(data, command)).hexdigest()
+    identifier = hashlib.sha1("{}{}".format(data, command)).hexdigest()
     if identifier not in big_data:
         big_data[identifier] = ''
     big_data[identifier] += out

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -10,11 +10,15 @@ import pickle
 import hashlib
 import re
 import urllib
-import HTMLParser
 import sys
 import traceback
 import collections
 import ssl
+
+try:
+    from html.parser import HTMLParser
+except ImportError:
+    from HTMLParser import HTMLParser
 
 from websocket import create_connection, WebSocketConnectionClosedException
 
@@ -739,7 +743,7 @@ class Channel(object):
                         r'\1\2{}\3'.format(user.formatted_name() + curr_color),
                         message)
 
-            message = HTMLParser.HTMLParser().unescape(message)
+            message = HTMLParser().unescape(message)
             data = u"{}\t{}".format(name, message).encode('utf-8')
             w.prnt_date_tags(self.channel_buffer, time_int, tags, data)
 
@@ -2480,7 +2484,7 @@ class PluginConfig(object):
     # Set missing settings to their defaults. Load non-missing settings from
     # weechat configs.
     def __init__(self):
-        for key,default in self.settings.iteritems():
+        for key,default in self.settings.items():
             if not w.config_get_plugin(key):
                 w.config_set_plugin(key, default)
         self.config_changed(None, None, None)
@@ -2506,7 +2510,10 @@ class PluginConfig(object):
             return self.get_boolean(key)
 
     def __getattr__(self, key):
-        return self.settings[key]
+        try:
+            return self.settings[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def get_boolean(self, key):
         return w.config_string_to_boolean(w.config_get_plugin(key))


### PR DESCRIPTION
This makes the tests for wee_slack pass on Python 3. This does not guarantee Python 3 support in wee_slack, but it provides a good starting point.

This does not break Python 2 support. All of these changes should be compatible with Python 2 and 3.