### PR TITLE
Translate slack formatting codes to/from IRC formatting codes

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2225,6 +2225,10 @@ def render(message_json, team, channel, force=False):
         text = text.replace("&lt;", "<")
         text = text.replace("&gt;", ">")
         text = text.replace("&amp;", "&")
+        text = re.sub(r'(^| )\*([^*]+)\*([^a-zA-Z0-9_]|$)',
+                      r'\1{}\2{}\3'.format(w.color('bold'), w.color('-bold')), text)
+        text = re.sub(r'(^| )_([^_]+)_([^a-zA-Z0-9_]|$)',
+                      r'\1{}\2{}\3'.format(w.color('underline'), w.color('-underline')), text)
 
         if type(text) is not unicode:
             text = text.decode('UTF-8', 'replace')
@@ -2245,7 +2249,7 @@ def linkify_text(message, team, channel):
     # function is only called on message send..
     usernames = team.get_username_map()
     channels = team.get_channel_map()
-    message = message.split(' ')
+    message = message.replace('\x02', '*').replace('\x1F', '_').split(' ')
     for item in enumerate(message):
         targets = re.match('^\s*([@#])([\w.-]+[\w. -])(\W*)', item[1])
         #print targets


### PR DESCRIPTION
This translates `*` into bold and `_` into underline (since most IRC clients don't support italics). It also properly handles outgoing `\x02` and `\x1F` characters.

Signed-off-by: Ben Kelly <btk@google.com>
Signed-off-by: Ben Kelly <bk@ancilla.ca>