### PR TITLE
wrong var name

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2579,7 +2579,7 @@ def command_talk(data, current_buffer, args):
             c = team.get_channel_map()
 
     if channel_name.startswith('#'):
-        channel_name = arg[1:]
+        channel_name = channel_name[1:]
     if channel_name in c:
         chan = team.channels[c[channel_name]]
         chan.open()


### PR DESCRIPTION
fixes the join command because joining channels is useful. sometimes.