### PR TITLE
Add command for setting Slack Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A WeeChat native client for Slack.com. Provides supplemental features only avail
 Features
 --------
   * **New** [Threads](#threads) support!
+  * **New** [Slack Status](#status) support!
   * Slash commands (including custom ones!)
   * Upload to slack capabilities!
   * Emoji reactions!
@@ -208,6 +209,18 @@ Label a thread with a memorable name. The above command will open a channel call
 /label meetingnotes
 ```
 _Note: labels do not persist once a thread buffer is closed_
+
+#### Status
+
+Set your Slack status on a given team:
+```
+/slack status [:emoji:] [Status message]
+```
+
+Example:
+```
+/slack status :ghost: Boo!
+```
 
 Optional settings
 -----------------

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2780,7 +2780,6 @@ def command_status(data, current_buffer, args):
 
         profile = {"status_text":text,"status_emoji":emoji}
 
-        team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
         s = SlackRequest(team.token, "users.profile.set", {"profile": profile}, team_hash=team.team_hash, channel_identifier=channel.identifier)
         EVENTROUTER.receive(s)
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2760,6 +2760,32 @@ def command_away(data, current_buffer, args):
 
 
 @slack_buffer_required
+def command_status(data, current_buffer, args):
+    """
+    Lets you set your Slack Status (not to be confused with away/here)
+    /slack status [emoji] [status_message]
+    """
+    e = EVENTROUTER
+    channel = e.weechat_controller.buffers.get(current_buffer, None)
+    if channel:
+        team = channel.team
+
+        if args is None:
+            server.buffer_prnt("Usage: /slack status [status emoji] [status text].")
+            return
+
+        split_args = args.split(None, 2)
+        emoji = split_args[1] if len(split_args) > 1 else ""
+        text = split_args[2] if len(split_args) > 2 else ""
+
+        profile = {"status_text":text,"status_emoji":emoji}
+
+        team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
+        s = SlackRequest(team.token, "users.profile.set", {"profile": profile}, team_hash=team.team_hash, channel_identifier=channel.identifier)
+        EVENTROUTER.receive(s)
+
+
+@slack_buffer_required
 def command_back(data, current_buffer, args):
     """
     Sets your status as 'back'


### PR DESCRIPTION
Add in a command called `/slack status`, allowing users to set or clear their Slack Status. 
Usage:

`/slack status [:emoji:] [Status message]`