### PR TITLE
Proper support for unicode

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -287,7 +287,7 @@ class EventRouter(object):
         """
         try:
             # Read the data from the websocket associated with this team.
-            data = self.teams[team_hash].ws.recv()
+            data = decode_from_utf8(self.teams[team_hash].ws.recv())
             message_json = json.loads(data)
             metadata = WeeSlackMetadata({
                 "team": team_hash,
@@ -858,7 +858,7 @@ class SlackRequest(object):
         post_data["token"] = token
         self.post_data = post_data
         self.params = {'useragent': 'wee_slack {}'.format(SCRIPT_VERSION)}
-        self.url = 'https://{}/api/{}?{}'.format(self.domain, request, urllib.urlencode(post_data))
+        self.url = 'https://{}/api/{}?{}'.format(self.domain, request, urllib.urlencode(encode_to_utf8(post_data)))
         self.response_id = sha.sha("{}{}".format(self.url, self.start_time)).hexdigest()
         self.retries = kwargs.get('retries', 3)
 #    def __repr__(self):
@@ -1053,7 +1053,7 @@ class SlackTeam(object):
         try:
             if expect_reply:
                 self.ws_replies[data["id"]] = data
-            self.ws.send(message)
+            self.ws.send(encode_to_utf8(message))
             dbg("Sent {}...".format(message[:100]))
         except:
             print "WS ERROR"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -559,6 +559,7 @@ def receive_httprequest_callback(data, command, return_code, out, err):
     This is a dirty hack. There must be a better way.
     """
     # def url_processor_cb(data, command, return_code, out, err):
+    data = decode_from_utf8(data)
     EVENTROUTER.receive_httprequest_callback(data, command, return_code, out, err)
     return w.WEECHAT_RC_OK
 
@@ -587,6 +588,7 @@ def buffer_closing_callback(signal, sig_type, data):
     that is the only way we can do dependency injection via weechat
     callback, hence the eval.
     """
+    data = decode_from_utf8(data)
     eval(signal).weechat_controller.unregister_buffer(data, True, False)
     return w.WEECHAT_RC_OK
 
@@ -598,6 +600,7 @@ def buffer_input_callback(signal, buffer_ptr, data):
     this includes add/remove reactions, modifying messages, and
     sending messages.
     """
+    data = decode_from_utf8(data)
     eventrouter = eval(signal)
     channel = eventrouter.weechat_controller.get_channel_from_buffer_ptr(buffer_ptr)
     if not channel:
@@ -633,6 +636,7 @@ def buffer_switch_callback(signal, sig_type, data):
     1) set read marker 2) determine if we have already populated
     channel history data
     """
+    data = decode_from_utf8(data)
     eventrouter = eval(signal)
 
     prev_buffer_ptr = eventrouter.weechat_controller.get_previous_buffer_ptr()
@@ -659,6 +663,7 @@ def buffer_list_update_callback(data, somecount):
     to indicate typing via "#channel" <-> ">channel" and
     user presence via " name" <-> "+name".
     """
+    data = decode_from_utf8(data)
     eventrouter = eval(data)
     # global buffer_list_update
 
@@ -678,6 +683,7 @@ def quit_notification_callback(signal, sig_type, data):
 
 
 def typing_notification_cb(signal, sig_type, data):
+    data = decode_from_utf8(data)
     msg = w.buffer_get_string(data, "input")
     if len(msg) > 8 and msg[:1] != "/":
         global typing_timer
@@ -694,11 +700,13 @@ def typing_notification_cb(signal, sig_type, data):
 
 
 def typing_update_cb(data, remaining_calls):
+    data = decode_from_utf8(data)
     w.bar_item_update("slack_typing_notice")
     return w.WEECHAT_RC_OK
 
 
 def slack_never_away_cb(data, remaining_calls):
+    data = decode_from_utf8(data)
     if config.never_away:
         for t in EVENTROUTER.teams.values():
             slackbot = t.get_channel_map()['slackbot']
@@ -747,6 +755,8 @@ def nick_completion_cb(data, completion_item, current_buffer, completion):
     Adds all @-prefixed nicks to completion list
     """
 
+    data = decode_from_utf8(data)
+    completion = decode_from_utf8(completion)
     current_buffer = w.current_buffer()
     current_channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
 
@@ -764,6 +774,8 @@ def emoji_completion_cb(data, completion_item, current_buffer, completion):
     Adds all :-prefixed emoji to completion list
     """
 
+    data = decode_from_utf8(data)
+    completion = decode_from_utf8(completion)
     current_buffer = w.current_buffer()
     current_channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
 
@@ -782,6 +794,8 @@ def complete_next_cb(data, current_buffer, command):
 
     """
 
+    data = decode_from_utf8(data)
+    command = decode_from_utf8(data)
     current_buffer = w.current_buffer()
     current_channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
 
@@ -2701,6 +2715,8 @@ def tag(tagset, user=None):
 
 @slack_buffer_or_ignore
 def part_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     e = EVENTROUTER
     args = args.split()
     if len(args) > 1:
@@ -2735,6 +2751,8 @@ def command_topic(data, current_buffer, args):
     Change the topic of a channel
     /slack topic [<channel>] [<topic>|-delete]
     """
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     e = EVENTROUTER
     team = e.weechat_controller.buffers[current_buffer].team
     # server = servers.find(current_domain_name())
@@ -2760,6 +2778,8 @@ def command_topic(data, current_buffer, args):
 
 @slack_buffer_or_ignore
 def me_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     message = "_{}_".format(args.split(' ', 1)[1])
     buffer_input_callback("EVENTROUTER", current_buffer, message)
     return w.WEECHAT_RC_OK_EAT
@@ -2767,6 +2787,8 @@ def me_command_cb(data, current_buffer, args):
 
 @slack_buffer_or_ignore
 def msg_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     dbg("msg_command_cb")
     aargs = args.split(None, 2)
     who = aargs[1]
@@ -2789,6 +2811,8 @@ def command_talk(data, current_buffer, args):
     /slack talk [user]
     """
 
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     e = EVENTROUTER
     team = e.weechat_controller.buffers[current_buffer].team
     channel_name = args.split(' ')[1]
@@ -2819,6 +2843,8 @@ def command_showmuted(data, current_buffer, args):
 
 
 def thread_command_callback(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     current = w.current_buffer()
     channel = EVENTROUTER.weechat_controller.buffers.get(current)
     if channel:
@@ -2847,6 +2873,8 @@ def thread_command_callback(data, current_buffer, args):
 
 
 def rehistory_command_callback(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     current = w.current_buffer()
     channel = EVENTROUTER.weechat_controller.buffers.get(current)
     channel.got_history = False
@@ -2857,6 +2885,8 @@ def rehistory_command_callback(data, current_buffer, args):
 
 @slack_buffer_required
 def hide_command_callback(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     c = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
     if c:
         name = c.formatted_name(style='long_default')
@@ -2866,6 +2896,8 @@ def hide_command_callback(data, current_buffer, args):
 
 
 def slack_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     a = args.split(' ', 1)
     if len(a) > 1:
         function_name, args = a[0], args
@@ -2975,6 +3007,8 @@ def command_upload(data, current_buffer, args):
 
 
 def away_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     # TODO: reimplement all.. maybe
     (all, message) = re.match("^/away(?:\s+(-all))?(?:\s+(.+))?", args).groups()
     if message is None:
@@ -3008,6 +3042,8 @@ def command_back(data, current_buffer, args):
 
 @slack_buffer_required
 def label_command_cb(data, current_buffer, args):
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
     channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer)
     if channel and channel.type == 'thread':
         aargs = args.split(None, 2)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from functools import wraps
 
 import time
@@ -382,7 +384,7 @@ class EventRouter(object):
                 meta = j.get("wee_slack_metadata", None)
                 if meta:
                     try:
-                        if isinstance(meta, str):
+                        if isinstance(meta, basestring):
                             dbg("string of metadata")
                         team = meta.get("team", None)
                         if team:
@@ -442,7 +444,7 @@ class WeechatController(object):
         complete
         Adds a weechat buffer to the list of handled buffers for this EventRouter
         """
-        if isinstance(buffer_ptr, str):
+        if isinstance(buffer_ptr, basestring):
             self.buffers[buffer_ptr] = channel
         else:
             raise InvalidType(type(buffer_ptr))
@@ -452,7 +454,7 @@ class WeechatController(object):
         complete
         Adds a weechat buffer to the list of handled buffers for this EventRouter
         """
-        if isinstance(buffer_ptr, str):
+        if isinstance(buffer_ptr, basestring):
             try:
                 self.buffers[buffer_ptr].destroy_buffer(update_remote)
                 if close_buffer:
@@ -1822,11 +1824,11 @@ class SlackMessage(object):
         dbg(self.message_json)
 
     def get_sender(self, utf8=True):
-        name = u""
-        name_plain = u""
+        name = ""
+        name_plain = ""
         if 'bot_id' in self.message_json and self.message_json['bot_id'] is not None:
-            name = u"{} :]".format(self.team.bots[self.message_json["bot_id"]].formatted_name())
-            name_plain = u"{}".format(self.team.bots[self.message_json["bot_id"]].formatted_name(enable_color=False))
+            name = "{} :]".format(self.team.bots[self.message_json["bot_id"]].formatted_name())
+            name_plain = "{}".format(self.team.bots[self.message_json["bot_id"]].formatted_name(enable_color=False))
         elif 'user' in self.message_json:
             if self.message_json['user'] == self.team.myidentifier:
                 name = self.team.users[self.team.myidentifier].name
@@ -1834,19 +1836,19 @@ class SlackMessage(object):
             elif self.message_json['user'] in self.team.users:
                 u = self.team.users[self.message_json['user']]
                 if u.is_bot:
-                    name = u"{} :]".format(u.formatted_name())
+                    name = "{} :]".format(u.formatted_name())
                 else:
-                    name = u"{}".format(u.formatted_name())
-                name_plain = u"{}".format(u.formatted_name(enable_color=False))
+                    name = "{}".format(u.formatted_name())
+                name_plain = "{}".format(u.formatted_name(enable_color=False))
         elif 'username' in self.message_json:
-            name = u"-{}-".format(self.message_json["username"])
-            name_plain = u"{}".format(self.message_json["username"])
+            name = "-{}-".format(self.message_json["username"])
+            name_plain = "{}".format(self.message_json["username"])
         elif 'service_name' in self.message_json:
-            name = u"-{}-".format(self.message_json["service_name"])
-            name_plain = u"{}".format(self.message_json["service_name"])
+            name = "-{}-".format(self.message_json["service_name"])
+            name_plain = "{}".format(self.message_json["service_name"])
         else:
-            name = u""
-            name_plain = u""
+            name = ""
+            name_plain = ""
         if utf8:
             return (name.encode('utf-8'), name_plain.encode('utf-8'))
         else:
@@ -1861,9 +1863,9 @@ class SlackMessage(object):
                     r["users"].append(user)
                     found = True
             if not found:
-                self.message_json["reactions"].append({u"name": reaction, u"users": [user]})
+                self.message_json["reactions"].append({"name": reaction, "users": [user]})
         else:
-            self.message_json["reactions"] = [{u"name": reaction, u"users": [user]}]
+            self.message_json["reactions"] = [{"name": reaction, "users": [user]}]
 
     def remove_reaction(self, reaction, user):
         m = self.message_json.get('reactions', None)
@@ -2010,12 +2012,12 @@ def handle_rtmstart(login_data, eventrouter):
         #    return False
 
         t.buffer_prnt('Connected to Slack')
-        t.buffer_prnt('{:<20} {}'.format(u"Websocket URL", login_data["url"]))
-        t.buffer_prnt('{:<20} {}'.format(u"User name", login_data["self"]["name"]))
-        t.buffer_prnt('{:<20} {}'.format(u"User ID", login_data["self"]["id"]))
-        t.buffer_prnt('{:<20} {}'.format(u"Team name", login_data["team"]["name"]))
-        t.buffer_prnt('{:<20} {}'.format(u"Team domain", login_data["team"]["domain"]))
-        t.buffer_prnt('{:<20} {}'.format(u"Team id", login_data["team"]["id"]))
+        t.buffer_prnt('{:<20} {}'.format("Websocket URL", login_data["url"]))
+        t.buffer_prnt('{:<20} {}'.format("User name", login_data["self"]["name"]))
+        t.buffer_prnt('{:<20} {}'.format("User ID", login_data["self"]["id"]))
+        t.buffer_prnt('{:<20} {}'.format("Team name", login_data["team"]["name"]))
+        t.buffer_prnt('{:<20} {}'.format("Team domain", login_data["team"]["domain"]))
+        t.buffer_prnt('{:<20} {}'.format("Team id", login_data["team"]["id"]))
 
         dbg("connected to {}".format(t.domain))
 
@@ -2066,9 +2068,9 @@ def process_presence_change(message_json, eventrouter, **kwargs):
 
 def process_pref_change(message_json, eventrouter, **kwargs):
     team = kwargs["team"]
-    if message_json['name'] == u'muted_channels':
+    if message_json['name'] == 'muted_channels':
         team.set_muted_channels(message_json['value'])
-    elif message_json['name'] == u'highlight_words':
+    elif message_json['name'] == 'highlight_words':
         team.set_highlight_words(message_json['value'])
     else:
         dbg("Preference change not implemented: {}\n".format(message_json['name']))
@@ -2391,9 +2393,9 @@ def render(message_json, team, channel, force=False):
             if message_json['text'] is not None:
                 text = message_json["text"]
             else:
-                text = u""
+                text = ""
         else:
-            text = u""
+            text = ""
 
         text = unfurl_refs(text, ignore_alt_text=config.unfurl_ignore_alt_text)
 
@@ -2483,7 +2485,7 @@ def unfurl_ref(ref, ignore_alt_text=False):
                 display_text = ref.split('|')[1]
             else:
                 url, desc = ref.split('|', 1)
-                display_text = u"{} ({})".format(url, desc)
+                display_text = "{} ({})".format(url, desc)
     else:
         display_text = resolve_ref(ref)
     return display_text
@@ -2494,7 +2496,7 @@ def unwrap_attachments(message_json, text_before):
     a = message_json.get("attachments", None)
     if a:
         if text_before:
-            attachment_text = u'\n'
+            attachment_text = '\n'
         for attachment in a:
             # Attachments should be rendered roughly like:
             #

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1823,7 +1823,7 @@ class SlackMessage(object):
         self.suffix = new_suffix
         dbg(self.message_json)
 
-    def get_sender(self, utf8=True):
+    def get_sender(self):
         name = ""
         name_plain = ""
         if 'bot_id' in self.message_json and self.message_json['bot_id'] is not None:
@@ -1849,10 +1849,7 @@ class SlackMessage(object):
         else:
             name = ""
             name_plain = ""
-        if utf8:
-            return (name.encode('utf-8'), name_plain.encode('utf-8'))
-        else:
-            return (name, name_plain)
+        return (name, name_plain)
 
     def add_reaction(self, reaction, user):
         m = self.message_json.get('reactions', None)


### PR DESCRIPTION
This changes wee_slack to only use unicode strings internally, and encode/decode to utf-8 when it sends/receives data, which fixes some unicode errors that's been happening e.g. when editing non-ascii messages (hopefully fixes all unicode issues, but can't guarantee that). Some info from the first commit:

> This changes all strings to be unicode strings in an attempt to handle
> unicode better. The idea is to use unicode everywhere internally in
> wee_slack and decode/encode where data is received/sent to/from
> wee-slack.
> 
> That means we have to decode strings received from weechat or slack and
> encode strings we send to them. This way encoding and decoding is done
> on specific places, and if done everywhere, we should not get any
> unicode errors.

I've tested this briefly, but not much, so it probably needs some more testing before merging.

Relates to #345.