### PR TITLE
Fix channel history not appearing when an earlier message has 'text': None

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1859,8 +1859,8 @@ class SlackMessage(object):
             self.sender, self.sender_plain = senders[0], senders[1]
         self.suffix = ''
         self.ts = SlackTS(message_json['ts'])
-        text = self.message_json.get('text', '')
-        if text.startswith('_') and text.endswith('_') and 'subtype' not in message_json:
+        text = self.message_json.get('text')
+        if text and text.startswith('_') and text.endswith('_') and 'subtype' not in message_json:
             message_json['text'] = text[1:-1]
             message_json['subtype'] = 'me_message'
         if message_json.get('subtype') == 'me_message' and not message_json['text'].startswith(self.sender):


### PR DESCRIPTION
Today I learned that sometimes, rather than the key missing, it has the value
None. In this case, (key in dict) is true!

This fixes an issue where, if the backscroll of a channel contained such a
message, it would throw while fetching the backscroll and cut off without
fetching all of it.

Signed-off-by: Ben Kelly <btk@google.com>
Signed-off-by: Ben Kelly <bk@ancilla.ca>