### PR TITLE
Add a command for opening an editor to compose a multiline message

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3264,6 +3264,7 @@ class PluginConfig(object):
         'debug_mode': 'false',
         'debug_level': '3',
         'distracting_channels': '',
+        'editor': '',
         'show_reaction_nicks': 'false',
         'slack_api_token': 'INSERT VALID KEY HERE!',
         'slack_timeout': '20000',

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -17,6 +17,7 @@ import collections
 import ssl
 import random
 import string
+import subprocess
 
 from websocket import create_connection, WebSocketConnectionClosedException
 
@@ -2800,6 +2801,46 @@ def msg_command_cb(data, current_buffer, args):
             channel = team.channels[cmap[channel]]
             channel.send_message(message)
     return w.WEECHAT_RC_OK_EAT
+
+@slack_buffer_required
+def command_longmsg(data, current_buffer, args):
+    """
+    Open an editor to draft a multiline message to be sent
+    as a single input
+    /slack longmsg
+    """
+    data = decode_from_utf8(data)
+    args = decode_from_utf8(args)
+    e = EVENTROUTER
+    team = e.weechat_controller.buffers[current_buffer].team
+    args = args.split(' ')
+    if len(args) > 1 and args[1].startswith('#'):
+        cmap = team.get_channel_map()
+        channel_name = args[1][1:]
+        channel = team.channels[cmap[channel_name]]
+    else:
+        channel = e.weechat_controller.buffers[current_buffer]
+
+    editor = (weechat.config_get_plugin("editor") or
+              os.environ.get("EDITOR", "vim -f"))
+    path = os.path.expanduser("~/.weechat/slack_longmsg.txt")
+    open(path, "w+")
+
+    cmd = editor.split() + [path]
+    code = subprocess.Popen(cmd).wait()
+    if code != 0:
+        os.remove(path)
+        weechat.command(current_buffer, "/window refresh")
+        return weechat.WEECHAT_RC_ERROR
+
+    with open(path) as f:
+        text = f.read()
+        channel.send_message(text)
+
+    os.remove(path)
+    weechat.command(current_buffer, "/window refresh")
+
+    return weechat.WEECHAT_RC_OK
 
 
 @slack_buffer_or_ignore


### PR DESCRIPTION
Borrows heavily from https://github.com/keith/edit-weechat

The current syntax is `/slack longmsg` but maybe there is a better name for the command. Also unsure how to keep the terms of edit-weechat's license.

Fixes #118 