### PR TITLE
When expanding attachments avoid rendering same link multiple times

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2281,8 +2281,7 @@ def subprocess_message_changed(message_json, eventrouter, channel, team):
             else:
                 message_json["fallback"] = m["fallback"]
 
-    text_before = (len(new_message['text']) > 0)
-    new_message["text"] += unwrap_attachments(message_json, text_before)
+    new_message["text"] += unwrap_attachments(message_json, new_message["text"])
     if "edited" in new_message:
         channel.change_message(new_message["ts"], new_message["text"], ' (edited)')
     else:
@@ -2450,8 +2449,7 @@ def render(message_json, team, channel, force=False):
 
         text = unfurl_refs(text, ignore_alt_text=config.unfurl_ignore_alt_text)
 
-        text_before = (len(text) > 0)
-        text += unfurl_refs(unwrap_attachments(message_json, text_before), ignore_alt_text=config.unfurl_ignore_alt_text)
+        text += unfurl_refs(unwrap_attachments(message_json, text), ignore_alt_text=config.unfurl_ignore_alt_text)
 
         text = text.lstrip()
         text = text.replace("\t", "    ")
@@ -2558,14 +2556,18 @@ def unwrap_attachments(message_json, text_before):
             if 'pretext' in attachment:
                 t.append(attachment['pretext'])
             title = attachment.get('title', None)
-            title_link = attachment.get('title_link', None)
+            title_link = attachment.get('title_link', '')
+            if title_link in text_before:
+                title_link = ''
             if title and title_link:
                 t.append('%s%s (%s)' % (prepend_title_text, title, title_link,))
                 prepend_title_text = ''
             elif title and not title_link:
-                t.append(prepend_title_text + title)
+                t.append('%s%s' % (prepend_title_text, title,))
                 prepend_title_text = ''
-            t.append(attachment.get("from_url", ""))
+            from_url = attachment.get('from_url', '')
+            if from_url not in text_before:
+                t.append(from_url)
 
             atext = attachment.get("text", None)
             if atext:


### PR DESCRIPTION
When links are expanded it sometimes becomes unreadable as the same link is pasted over and over. For example:

<img width="711" alt="link_old" src="https://user-images.githubusercontent.com/6246622/27984759-f36e5758-63dd-11e7-94ad-566783a74dd2.png">

The longer the link the worse it gets. This PR avoids repeating the same link over and over:

<img width="710" alt="link_new" src="https://user-images.githubusercontent.com/6246622/27984762-026cef4e-63de-11e7-972e-8a3356b30eb2.png">