### PR TITLE
Fix bug https://github.com/wee-slack/wee-slack/issues/389

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -911,6 +911,7 @@ class SlackTeam(object):
         self.preferred_name = self.domain
         self.nick = nick
         self.myidentifier = myidentifier
+        self.identifier = myidentifier
         try:
             if self.channels:
                 for c in channels.keys():


### PR DESCRIPTION
This makes it possible to address a SlackTeam object as channel with
identifier attribute called "identifier"
I do not know if that's the proper fix, of if the status code should
call "myidentifier" instead.

I've seen this error elsewhere, so I suspect this is a more generic
fix/probably due to historical code/attribute naming.

Also it totally works fine for me with that (ie i can actually set
status now)