### PR TITLE
Fix nick coloring in weechat < 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,16 +225,6 @@ Example:
 Optional settings
 -----------------
 
-Turn off colorized nicks:
-```
-/set plugins.var.python.slack.colorize_nicks 0
-```
-
-Turn on colorized messages (messages match nick color):
-```
-/set plugins.var.python.slack.colorize_nicks 1
-```
-
 Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
 ```
 /set plugins.var.python.slack.server_aliases "my-slack-subdomain:mysub,other-domain:coolbeans"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3350,8 +3350,8 @@ if __name__ == "__main__":
     if w.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE,
                   SCRIPT_DESC, "script_unloaded", ""):
 
-        version = w.info_get("version_number", "") or 0
-        if int(version) < 0x1030000:
+        weechat_version = w.info_get("version_number", "") or 0
+        if int(weechat_version) < 0x1030000:
             w.prnt("", "\nERROR: Weechat version 1.3+ is required to use {}.\n\n".format(SCRIPT_NAME))
         else:
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -150,6 +150,13 @@ class WeechatWrapper(object):
             return decode_from_utf8(orig_attr)
 
 
+##### Helpers
+
+def get_nick_color_name(nick):
+    info_name_prefix = "irc_" if int(weechat_version) < 0x1050000 else ""
+    return w.info_get(info_name_prefix + "nick_color_name", nick)
+
+
 ##### BEGIN NEW
 
 IGNORED_EVENTS = [
@@ -1537,7 +1544,7 @@ class SlackDMChannel(SlackChannel):
 
     def update_color(self):
         if config.colorize_private_chats:
-            self.color_name = w.info_get('irc_nick_color_name', self.name)
+            self.color_name = get_nick_color_name(self.name)
             self.color = w.color(self.color_name)
         else:
             self.color = ""
@@ -1816,7 +1823,7 @@ class SlackUser(object):
     def update_color(self):
         # This will automatically be none/"" if the user has disabled nick
         # colourization.
-        self.color_name = w.info_get('nick_color_name', self.name)
+        self.color_name = get_nick_color_name(self.name)
         self.color = w.color(self.color_name)
 
     def formatted_name(self, prepend="", enable_color=True):


### PR DESCRIPTION
This should make nick colors work in weechat < 1.5 again by using either the info_name `irc_nick_color_name` or `nick_color_name` depending on the version. It also removes the outdated docks for the colorize_nicks option which doesn't exist anymore.

Replaces #318 since the last comment there never was addressed.

It would be great if someone with weechat 1.3 or 1.4 could verify that this actually fixes the issue.