### PR TITLE
Fix the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+.cache/
+*.sublime-*

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -71,6 +71,10 @@ class FakeWeechat():
         return "0x8a8a8a8b"
     def prefix(self, type):
         return ""
+    def config_get_plugin(self, key):
+        return ""
+    def color(self, name):
+        return ""
     def __getattr__(self, name):
         def method(*args):
             pass
@@ -87,6 +91,7 @@ def mock_weechat():
     wee_slack.slack_debug = "debug_buffer_ptr"
     wee_slack.STOP_TALKING_TO_SLACK = False
     wee_slack.proc = {}
+    wee_slack.weechat_version = 0x10500000
     pass
 
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3238,7 +3238,7 @@ class PluginConfig(object):
     # value is used to set the default for any settings not already defined.
     # Following this procedure, the keys remain the same, but the values are
     # the real (python) values of the settings.
-    settings = {
+    default_settings = {
         'background_load_all_history': Setting(
             default='false',
             desc='Load history for each channel in the background as soon as it'
@@ -3322,11 +3322,12 @@ class PluginConfig(object):
     # Set missing settings to their defaults. Load non-missing settings from
     # weechat configs.
     def __init__(self):
+        self.settings = {}
         # Set all descriptions, replace the values in the dict with the
         # default setting value rather than the (setting,desc) tuple.
         # Use items() rather than iteritems() so we don't need to worry about
         # invalidating the iterator.
-        for key, (default, desc) in self.settings.items():
+        for key, (default, desc) in self.default_settings.items():
             w.config_set_desc_plugin(key, desc)
             self.settings[key] = default
 


### PR DESCRIPTION
Not everything that needed to be mocked out was, and there was also an
issue with every instance of PluginConfig sharing the same mutable
settings field and thus stomping on each other if you initialized more
than one in the same test.

Signed-off-by: Ben Kelly <bk@ancilla.ca>
Signed-off-by: Ben Kelly <btk@google.com>