### PR TITLE
Don't send typing notifications for threads, since Slack doesn't like that

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -696,7 +696,7 @@ def typing_notification_cb(signal, sig_type, data):
         if typing_timer + 4 < now:
             current_buffer = w.current_buffer()
             channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
-            if channel:
+            if channel and channel.type != "thread":
                 identifier = channel.identifier
                 request = {"type": "typing", "channel": identifier}
                 channel.team.send_to_websocket(request, expect_reply=False)


### PR DESCRIPTION
Specifically, if you have debugging on you will get an exception for every single character typed in a thread, which makes debugging anything else kind of aggravating.

Signed-off-by: Ben Kelly <btk@google.com>
Signed-off-by: Ben Kelly <bk@ancilla.ca>