### PR TITLE
Fix overzealous regex in unfurl_refs

### DIFF
--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -10,17 +10,17 @@ slack = wee_slack
         'output': "foo",
     },
     {
-        'input': "<@U2147483697|@othernick>: foo",
-        'output': "@testuser: foo",
+        'input': "<@U407ABLLW|@othernick>: foo",
+        'output': "@alice: foo",
         'ignore_alt_text': True,
     },
     {
-        'input': "foo <#C2147483705|#otherchannel> foo",
+        'input': "foo <#C407ABS94|otherchannel> foo",
         'output': "foo #otherchannel foo",
     },
     {
-        'input': "foo <#C2147483705> foo",
-        'output': "foo #test-chan foo",
+        'input': "foo <#C407ABS94> foo",
+        'output': "foo #general foo",
     },
     {
         'input': "url: <https://example.com|example> suffix",
@@ -31,23 +31,17 @@ slack = wee_slack
         'output': "url: https://example.com (example with spaces) suffix",
     },
     {
-        'input': "<@U2147483697|@othernick> multiple unfurl <https://example.com|example with spaces>",
+        'input': "<@U407ABLLW|@othernick> multiple unfurl <https://example.com|example with spaces>",
         'output': "@othernick multiple unfurl https://example.com (example with spaces)",
     },
     {
-        'input': "try the #test-chan channel",
-        'output': "try the #test-chan channel",
+        'input': "try the #general channel",
+        'output': "try the #general channel",
     },
 ))
-def test_unfurl_refs(case):
-    pass
-    #print myslack
-    #slack.servers = myslack.server
-    #slack.channels = myslack.channel
-    #slack.users = myslack.user
-    #slack.message_cache = {}
-    #slack.servers[0].users = myslack.user
-    #print myslack.channel[0].identifier
+def test_unfurl_refs(case, realish_eventrouter):
+    slack.EVENTROUTER = realish_eventrouter
 
-    #assert slack.unfurl_refs(case['input'], ignore_alt_text=case.get('ignore_alt_text', False)) == case['output']
-
+    result = slack.unfurl_refs(
+        case['input'], ignore_alt_text=case.get('ignore_alt_text', False))
+    assert result == case['output']

--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -38,6 +38,10 @@ slack = wee_slack
         'input': "try the #general channel",
         'output': "try the #general channel",
     },
+    {
+        'input': "<@U407ABLLW> I think 3 > 2",
+        'output': "@alice I think 3 > 2",
+    },
 ))
 def test_unfurl_refs(case, realish_eventrouter):
     slack.EVENTROUTER = realish_eventrouter

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2110,7 +2110,7 @@ def handle_imopen(im_json, eventrouter, **kwargs):
     im = team.channels[request_metadata.channel_identifier]
     unread_count_display = im_json['channel']['unread_count_display']
     im.set_unread_count_display(unread_count_display)
- 
+
 def handle_groupshistory(message_json, eventrouter, **kwargs):
     handle_history(message_json, eventrouter, **kwargs)
 
@@ -2558,7 +2558,7 @@ def unfurl_refs(text, ignore_alt_text=False):
     #  - <#C2147483705|#otherchannel>
     #  - <@U2147483697|@othernick>
     # Test patterns lives in ./_pytest/test_unfurl.py
-    matches = re.findall(r"(<[@#]?(?:[^<]*)>)", text)
+    matches = re.findall(r"(<[@#]?(?:[^>]*)>)", text)
     for m in matches:
         # Replace them with human readable strings
         text = text.replace(m, unfurl_ref(m[1:-1], ignore_alt_text))


### PR DESCRIPTION
This fixes a bug where messages of the form `@person I think 3 > 2` end up trying to unfurl everything up to the *last* `>` in the message.

Signed-off-by: Ben Kelly <bk@ancilla.ca>
Signed-off-by: Ben Kelly <btk@google.com>
