### PR TITLE
Properly escape <&> when sending messages to Slack.

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2520,9 +2520,16 @@ def linkify_text(message, team, channel):
     usernames = team.get_username_map()
     channels = team.get_channel_map()
     message = (message
+        # Replace IRC formatting chars with Slack formatting chars.
         .replace('\x02', '*')
         .replace('\x1D', '_')
         .replace('\x1F', config.map_underline_to)
+        # Escape chars that have special meaning to Slack. Note that we do not
+        # (and should not) perform a full URL escaping here.
+        # See https://api.slack.com/docs/message-formatting for details.
+        .replace('<', '&lt')
+        .replace('>', '&gt')
+        .replace('&', '&amp')
         .split(' '))
     for item in enumerate(message):
         targets = re.match('^\s*([@#])([\w.-]+[\w. -])(\W*)', item[1])


### PR DESCRIPTION
Signed-off-by: Ben Kelly <bk@ancilla.ca>
Signed-off-by: Ben Kelly <btk@google.com>