### PR TITLE
Set correct number of unread messages in hotlist

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1141,7 +1141,7 @@ class SlackChannel(object):
 
     def set_unread_count_display(self, count):
         self.unread_count_display = count
-        if (self.unread_count_display > 0):
+        for c in range(self.unread_count_display):
             if self.type == "im":
                 w.buffer_set(self.channel_buffer, "hotlist", "2")
             else:


### PR DESCRIPTION
While the commit 6718e2f fixed buffers not appearing in the hotlist,
after it the number of new messages for each buffer was gone. This makes
the number of messages for each buffer shown again.