### PR TITLE
Improve rendering of changes in multiline messages

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2742,6 +2742,9 @@ def modify_buffer_line(buffer, new_line, timestamp, time_id):
 
         # split the message into at most the number of existing lines
         lines = new_line.split('\n', number_of_matching_lines - 1)
+        # updating a line with a string containing newlines causes the lines to
+        # be broken when viewed in bare display mode
+        lines = [line.replace('\n', ' | ') for line in lines]
         # pad the list with empty strings until the number of elements equals
         # number_of_matching_lines
         lines += [''] * (number_of_matching_lines - len(lines))

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2733,6 +2733,10 @@ def modify_buffer_line(buffer, new_line, timestamp, time_id):
                     # since number_of_matching_lines is non-zero, we have
                     # already reached the message and can stop traversing
                     break
+            else:
+                dbg(('Encountered line without any data while trying to modify '
+                    'line. This is not handled, so aborting modification.'))
+                return w.WEECHAT_RC_ERROR
             # move backwards one line and try again - exit the while if you hit the end
             line_pointer = w.hdata_move(struct_hdata_line, line_pointer, -1)
 
@@ -2772,6 +2776,9 @@ def modify_print_time(buffer, new_id, time):
             if data:
                 prefix = w.hdata_string(struct_hdata_line_data, data, 'prefix')
                 w.hdata_update(struct_hdata_line_data, data, {"date_printed": new_id})
+            else:
+                dbg('Encountered line without any data while setting message id.')
+                return w.WEECHAT_RC_ERROR
             # move backwards one line and repeat, so all the lines of the message are set
             # exit when you reach a prefix, which means you have reached the
             # first line of the message, or if you hit the end

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2751,10 +2751,17 @@ def modify_print_time(buffer, new_id, time):
         struct_hdata_line = w.hdata_get('line')
         struct_hdata_line_data = w.hdata_get('line_data')
 
-        # get a pointer to the data in line_pointer via layout of struct_hdata_line
-        data = w.hdata_pointer(struct_hdata_line, line_pointer, 'data')
-        if data:
-            w.hdata_update(struct_hdata_line_data, data, {"date_printed": new_id})
+        prefix = ''
+        while not prefix and line_pointer:
+            # get a pointer to the data in line_pointer via layout of struct_hdata_line
+            data = w.hdata_pointer(struct_hdata_line, line_pointer, 'data')
+            if data:
+                prefix = w.hdata_string(struct_hdata_line_data, data, 'prefix')
+                w.hdata_update(struct_hdata_line_data, data, {"date_printed": new_id})
+            # move backwards one line and repeat, so all the lines of the message are set
+            # exit when you reach a prefix, which means you have reached the
+            # first line of the message, or if you hit the end
+            line_pointer = w.hdata_move(struct_hdata_line, line_pointer, -1)
 
     return w.WEECHAT_RC_OK
 


### PR DESCRIPTION
This improves rendering when multiline messages are changed or reacted to, by updating each line of the existing message instead of cramming all of the new message into the last line. That means that if the number of lines in the message doesn't change, the message will still be rendered correctly after edits or reactions.

If the number of lines change, the rendering is still improved, however I don't know if it is possible to insert or delete lines in a weechat buffer without re-rendering the whole buffer, so it won't be perfect. If the number of lines of a message decreases after an edit, the extra lines will still be present, but they will be blanked. If the number of lines increases, the first lines will be set as normally, but the last line will contain all of the rest of the lines.