### PR TITLE
Fix HTML entity-encoding of outgoing messages

### DIFF
--- a/_pytest/test_linkifytext.py
+++ b/_pytest/test_linkifytext.py
@@ -4,3 +4,12 @@ from wee_slack import linkify_text
 #    linkify_text('@ryan')
 
 #    assert False
+
+
+def test_linkifytext_does_partial_html_entity_encoding(mock_weechat, realish_eventrouter):
+    team = realish_eventrouter.teams.values()[0]
+    channel = team.channels.values()[0]
+
+    text = linkify_text('& < > \' "', team, channel)
+
+    assert text == '&amp; &lt; &gt; \' "'

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2541,11 +2541,11 @@ def linkify_text(message, team, channel):
         .replace('\x1D', '_')
         .replace('\x1F', config.map_underline_to)
         # Escape chars that have special meaning to Slack. Note that we do not
-        # (and should not) perform a full URL escaping here.
+        # (and should not) perform full HTML entity-encoding here.
         # See https://api.slack.com/docs/message-formatting for details.
-        .replace('<', '&lt')
-        .replace('>', '&gt')
-        .replace('&', '&amp')
+        .replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
         .split(' '))
     for item in enumerate(message):
         targets = re.match('^\s*([@#])([\w.-]+[\w. -])(\W*)', item[1])


### PR DESCRIPTION
As pointed out by @auscompgeek on IRC, the HTML entity-encoding is broken. If you send e.g. `<test>`, it will be printed as `&amplttest&ampgt` in wee-slack and `&lttest&gt` in the web client.

We have to replace the & before we replace < and >, otherwise the & in &lt; and &gt; are going to be replaced. Additionally, we need to end the sequences with ; which was missing.