### PR TITLE
Check that the bot_id exists before using it

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1911,7 +1911,7 @@ class SlackMessage(object):
     def get_sender(self):
         name = ""
         name_plain = ""
-        if 'bot_id' in self.message_json and self.message_json['bot_id'] is not None:
+        if self.message_json.get('bot_id') in self.team.bots:
             name = "{} :]".format(self.team.bots[self.message_json["bot_id"]].formatted_name())
             name_plain = "{}".format(self.team.bots[self.message_json["bot_id"]].formatted_name(enable_color=False))
         elif 'user' in self.message_json:


### PR DESCRIPTION
Instead of just checking that bot_id is not None, check that it exists
in the list of bots. This prevents a KeyError when trying to access a
bot that doesn't exist in the list.

This KeyError would happen if you use a reminder. The message from
slackbot then has bot_id B01 which is not in the list of bots from
rtm.start and gives bot_not_found if trying to look it up with the
bots.info API endpoint.

By ignoring the bot_id we fall back to the user/username, which in the
case of reminders is slackbot, so the name appears just as the other
messages from slackbot.

Fixes #420