### PR TITLE
Attachment tests and minor fixes

### DIFF
--- a/_pytest/test_unwrap_attachments.py
+++ b/_pytest/test_unwrap_attachments.py
@@ -1,0 +1,115 @@
+import wee_slack
+import pytest
+
+
+@pytest.mark.parametrize('case', (
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+        }]},
+        'input_text_before': "Text before",
+        'output': "\n".join([
+            "",
+            "Title",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+            'text': 'Attachment text',
+            'title_link': 'http://title.link',
+            'from_url': 'http://from.url',
+            'fallback': 'Fallback',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "Title (http://title.link)",
+            "http://from.url",
+            "Attachment text",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+            'text': 'Attachment text',
+            'title_link': 'http://link',
+            'from_url': 'http://link',
+        }]},
+        'input_text_before': "http://link",
+        'output': "\n".join([
+            "",
+            "Title",
+            "Attachment text",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+            'text': 'Attachment text\n\n\nWith multiple lines',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "Title",
+            "Attachment text\nWith multiple lines",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+            'author_name': 'Author',
+            'pretext': 'Pretext',
+            'text': 'Attachment text',
+            'title_link': 'http://title.link',
+            'from_url': 'http://from.url',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "Pretext",
+            "Author: Title (http://title.link)",
+            "http://from.url",
+            "Attachment text",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'author_name': 'Author',
+            'text': 'Attachment text',
+            'title_link': 'http://title.link',
+            'from_url': 'http://from.url',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "http://from.url",
+            "Author: Attachment text",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'fallback': 'Fallback',
+        }]},
+        'input_text_before': "",
+        'output': "Fallback",
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
+            'fields': [{
+                'title': 'First field title',
+                'value': 'First field value',
+            }, {
+                'title': '',
+                'value': 'Second field value',
+            }],
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "Title",
+            "First field title First field value",
+            "Second field value",
+        ]),
+    },
+))
+def test_unwrap_attachments(case):
+    result = wee_slack.unwrap_attachments(
+        case['input_message'], case['input_text_before'])
+    assert result == case['output']

--- a/_pytest/test_unwrap_attachments.py
+++ b/_pytest/test_unwrap_attachments.py
@@ -121,6 +121,28 @@ import pytest
             "Second field value",
         ]),
     },
+    {
+        'input_message': {'attachments': [{
+            'title': 'First attachment title',
+            'text': 'First attachment text',
+            'title_link': 'http://title.link.1',
+            'from_url': 'http://from.url.1',
+        }, {
+            'title': 'Second attachment title',
+            'text': 'Second attachment text',
+            'title_link': 'http://title.link.2',
+            'from_url': 'http://from.url.2',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "First attachment title (http://title.link.1)",
+            "http://from.url.1",
+            "First attachment text",
+            "Second attachment title (http://title.link.2)",
+            "http://from.url.2",
+            "Second attachment text",
+        ]),
+    },
 ))
 def test_unwrap_attachments(case):
     result = wee_slack.unwrap_attachments(

--- a/_pytest/test_unwrap_attachments.py
+++ b/_pytest/test_unwrap_attachments.py
@@ -45,6 +45,19 @@ import pytest
     {
         'input_message': {'attachments': [{
             'title': 'Title',
+            'text': 'Attachment text',
+            'title_link': 'http://link',
+            'from_url': 'http://link',
+        }]},
+        'input_text_before': "",
+        'output': "\n".join([
+            "Title (http://link)",
+            "Attachment text",
+        ]),
+    },
+    {
+        'input_message': {'attachments': [{
+            'title': 'Title',
             'text': 'Attachment text\n\n\nWith multiple lines',
         }]},
         'input_text_before': "",

--- a/_pytest/test_unwrap_attachments.py
+++ b/_pytest/test_unwrap_attachments.py
@@ -32,10 +32,10 @@ import pytest
         'input_message': {'attachments': [{
             'title': 'Title',
             'text': 'Attachment text',
-            'title_link': 'http://link',
-            'from_url': 'http://link',
+            'title_link': 'http://link?a=1&b=2',
+            'from_url': 'http://link?a=1&b=2',
         }]},
-        'input_text_before': "http://link",
+        'input_text_before': "http://link?a=1&amp;b=2",
         'output': "\n".join([
             "",
             "Title",

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2629,7 +2629,7 @@ def unwrap_attachments(message_json, text_before):
                 t.append('%s%s' % (prepend_title_text, title,))
                 prepend_title_text = ''
             from_url = attachment.get('from_url', '')
-            if from_url not in text_before:
+            if from_url not in text_before and from_url != title_link:
                 t.append(from_url)
 
             atext = attachment.get("text", None)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2600,11 +2600,11 @@ def unhtmlescape(text):
 
 
 def unwrap_attachments(message_json, text_before):
-    attachment_text = ''
+    attachment_texts = []
     a = message_json.get("attachments", None)
     if a:
         if text_before:
-            attachment_text = '\n'
+            attachment_texts.append('')
         for attachment in a:
             # Attachments should be rendered roughly like:
             #
@@ -2647,8 +2647,8 @@ def unwrap_attachments(message_json, text_before):
             fallback = attachment.get("fallback", None)
             if t == [] and fallback:
                 t.append(fallback)
-            attachment_text += "\n".join([x.strip() for x in t if x])
-    return attachment_text
+            attachment_texts.append("\n".join([x.strip() for x in t if x]))
+    return "\n".join(attachment_texts)
 
 
 def resolve_ref(ref):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2600,6 +2600,7 @@ def unhtmlescape(text):
 
 
 def unwrap_attachments(message_json, text_before):
+    text_before_unescaped = unhtmlescape(text_before)
     attachment_texts = []
     a = message_json.get("attachments", None)
     if a:
@@ -2620,7 +2621,7 @@ def unwrap_attachments(message_json, text_before):
                 t.append(attachment['pretext'])
             title = attachment.get('title', None)
             title_link = attachment.get('title_link', '')
-            if title_link in text_before:
+            if title_link in text_before_unescaped:
                 title_link = ''
             if title and title_link:
                 t.append('%s%s (%s)' % (prepend_title_text, title, title_link,))
@@ -2629,7 +2630,7 @@ def unwrap_attachments(message_json, text_before):
                 t.append('%s%s' % (prepend_title_text, title,))
                 prepend_title_text = ''
             from_url = attachment.get('from_url', '')
-            if from_url not in text_before and from_url != title_link:
+            if from_url not in text_before_unescaped and from_url != title_link:
                 t.append(from_url)
 
             atext = attachment.get("text", None)


### PR DESCRIPTION
- Adds tests for `unwrap_attachments`.
- Adds a newline between attachments, when there are multiple attachments.
- Prevents links from being printed twice when title_link and from_url are the same link, and that link doesn't appear in the message text (if it appears in the message text, that is already handled with #387).