### PR TITLE
Ensure that all lines printed to weechat specifies a prefix

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -156,6 +156,12 @@ class WeechatWrapper(object):
         else:
             return decode_from_utf8(orig_attr)
 
+    # Ensure all lines sent to weechat specifies a prefix. For lines after the
+    # first, we want to disable the prefix, which is done by specifying a space.
+    def prnt_date_tags(self, buffer, date, tags, message):
+        message = message.replace("\n", "\n \t")
+        return self.wrap_for_utf8(self.wrapped_class.prnt_date_tags)(buffer, date, tags, message)
+
 
 ##### Helpers
 


### PR DESCRIPTION
When we print a message with multiple lines to weechat, we want the nick/prefix to appear on the first line, and no prefix on the subsequent lines.

When this message is handled by weechat, it processes each line of the message separately, and applies a prefix for each line. It seems to me that if the line doesn't contain any tab characters, it should end up with an empty prefix, and this is what happens for me.

However, some users are having issues where both the prefix and the message ends up incorrect (issue #274, #385 and #421), which seems to be related to this.

Additionally, if the message contains a tab character on any of the lines after the first, the part before the tab character would be the prefix for that line, which is completely wrong. I haven't seen that happen, as it seems that slack replaces tab characters with spaces, but we should handle it correctly nevertheless.

The weechat documentation states that you should use a space followed by a tab character to disable the prefix. This patch inserts this after each newline, so the prefix is disabled for each line except the first.

I can't reproduce the issue, so I can't verify if this fixes the issue. As far as I can see, for me the behavior is the same with this patch.

Hopefully, this fixes #274.
