### PR TITLE
Use the timestamp of the last message in mark_read

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1445,7 +1445,8 @@ class SlackChannel(object):
 
     def mark_read(self, ts=None, update_remote=True, force=False):
         if not ts:
-            ts = SlackTS()
+            msg_timestamps = self.sorted_message_keys()
+            ts = msg_timestamps[-1] if msg_timestamps else SlackTS()
         if self.new_messages or force:
             if self.channel_buffer:
                 w.buffer_set(self.channel_buffer, "unread", "")


### PR DESCRIPTION
When sending a mark read message to slack, use the timestamp of the last message in the channel, instead of the current timestamp. This should prevent potentially marking messages as read, if they arrive after mark_read was called and the clock of the slack server and the machine wee-slack runs on is not exactly in sync.

According to issue #307 messages might also be marked as read if they arrive right after you switch buffer, and you have a slow internet connection. Though, since the time used in mark_read is set synchronously when the buffer is changed, I'm not sure if that can be the case. Either way, I think this patch should fix the issue.

If there are no messages in the channel, fall back to using the current time as timestamp.

Fixes #307