### PR TITLE
fix: Make /topic behave the same way as on IRC

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -49,7 +49,9 @@ class FakeWeechat():
     this is the thing that acts as "w." everywhere..
     basically mock out all of the weechat calls here i guess
     """
-    WEECHAT_RC_OK = True
+    WEECHAT_RC_ERROR = 0
+    WEECHAT_RC_OK = 1
+    WEECHAT_RC_OK_EAT = 2
 
     def __init__(self):
         pass

--- a/_pytest/test_topic_command.py
+++ b/_pytest/test_topic_command.py
@@ -1,0 +1,44 @@
+from wee_slack import parse_topic_command
+
+
+def test_parse_topic_without_arguments():
+    channel_name, topic = parse_topic_command('/topic')
+
+    assert channel_name is None
+    assert topic is None
+
+
+def test_parse_topic_with_text():
+    channel_name, topic = parse_topic_command('/topic some topic text')
+
+    assert channel_name is None
+    assert topic == 'some topic text'
+
+
+def test_parse_topic_with_delete():
+    channel_name, topic = parse_topic_command('/topic -delete')
+
+    assert channel_name is None
+    assert topic == ''
+
+
+def test_parse_topic_with_channel():
+    channel_name, topic = parse_topic_command('/topic #general')
+
+    assert channel_name == 'general'
+    assert topic is None
+
+
+def test_parse_topic_with_channel_and_text():
+    channel_name, topic = parse_topic_command(
+        '/topic #general some topic text')
+
+    assert channel_name == 'general'
+    assert topic == 'some topic text'
+
+
+def test_parse_topic_with_channel_and_delete():
+    channel_name, topic = parse_topic_command('/topic #general -delete')
+
+    assert channel_name == 'general'
+    assert topic == ''

--- a/_pytest/test_topic_command.py
+++ b/_pytest/test_topic_command.py
@@ -1,4 +1,6 @@
-from wee_slack import parse_topic_command
+import wee_slack
+from wee_slack import parse_topic_command, topic_command_cb
+from mock import patch
 
 
 def test_parse_topic_without_arguments():
@@ -42,3 +44,53 @@ def test_parse_topic_with_channel_and_delete():
 
     assert channel_name == 'general'
     assert topic == ''
+
+
+def test_call_topic_without_arguments(realish_eventrouter):
+    team = realish_eventrouter.teams.values()[-1]
+    channel = team.channels.values()[-1]
+    current_buffer = channel.channel_buffer
+    wee_slack.EVENTROUTER = realish_eventrouter
+
+    command = '/topic'
+
+    with patch('wee_slack.w.prnt') as fake_prnt:
+        result = topic_command_cb(None, current_buffer, command)
+        fake_prnt.assert_called_with(
+            channel.channel_buffer,
+            'Topic for {} is "{}"'.format(channel.name, channel.topic),
+        )
+        assert result == wee_slack.w.WEECHAT_RC_OK_EAT
+
+
+def test_call_topic_with_unknown_channel(realish_eventrouter):
+    team = realish_eventrouter.teams.values()[-1]
+    channel = team.channels.values()[-1]
+    current_buffer = channel.channel_buffer
+    wee_slack.EVENTROUTER = realish_eventrouter
+
+    command = '/topic #nonexisting'
+
+    with patch('wee_slack.w.prnt') as fake_prnt:
+        result = topic_command_cb(None, current_buffer, command)
+        fake_prnt.assert_called_with(
+            team.channel_buffer,
+            "#nonexisting: No such channel",
+        )
+        assert result == wee_slack.w.WEECHAT_RC_OK_EAT
+
+
+def test_call_topic_with_channel_and_string(realish_eventrouter):
+    team = realish_eventrouter.teams.values()[-1]
+    channel = team.channels.values()[-1]
+    current_buffer = channel.channel_buffer
+    wee_slack.EVENTROUTER = realish_eventrouter
+
+    command = '/topic #general new topic'
+
+    result = topic_command_cb(None, current_buffer, command)
+    request = realish_eventrouter.queue[-1]
+    assert request.request == 'channels.setTopic'
+    assert request.post_data == {
+        'channel': 'C407ABS94', 'token': 'xoxoxoxox', 'topic': 'new topic'}
+    assert result == wee_slack.w.WEECHAT_RC_OK_EAT


### PR DESCRIPTION
This refactors the topic command, and makes it behave the same way as it does on IRC. The fixes include:

- `/topic` prints the topic instead of clearing it
- `/topic #channel` prints the topic for that channel in that channels buffer instead of setting the topic to #channel
- `/topic #channel [...]` for a channel that doesn't exist gives a proper error message

The patch also removes some unused code, refactors the logic and removes the `/slack topic` command, since using `/topic` should suffice.

The reason it returs WEECHAT_RC_OK_EAT when the channel isn't found, is so weechat doesn't print an error message such as:

    irc: command "topic" must be executed on irc buffer (server or channel)

Fixes #405