### PR TITLE
feat: Remove Slacks auto prefixing of url protocols

### DIFF
--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -31,6 +31,26 @@ slack = wee_slack
         'output': "url: https://example.com (example with spaces) suffix",
     },
     {
+        'input': "url: <https://example.com|example.com> suffix",
+        'output': "url: example.com suffix",
+        'auto_link_display': 'text',
+    },
+    {
+        'input': "url: <https://example.com|different text> suffix",
+        'output': "url: https://example.com (different text) suffix",
+        'auto_link_display': 'text',
+    },
+    {
+        'input': "url: <https://example.com|different text> suffix",
+        'output': "url: https://example.com (different text) suffix",
+        'auto_link_display': 'url',
+    },
+    {
+        'input': "url: <https://example.com|example.com> suffix",
+        'output': "url: https://example.com suffix",
+        'auto_link_display': 'url',
+    },
+    {
         'input': "<@U407ABLLW|@othernick> multiple unfurl <https://example.com|example with spaces>",
         'output': "@othernick multiple unfurl https://example.com (example with spaces)",
     },
@@ -47,5 +67,8 @@ def test_unfurl_refs(case, realish_eventrouter):
     slack.EVENTROUTER = realish_eventrouter
 
     result = slack.unfurl_refs(
-        case['input'], ignore_alt_text=case.get('ignore_alt_text', False))
+        case['input'],
+        ignore_alt_text=case.get('ignore_alt_text', False),
+        auto_link_display=case.get('auto_link_display', 'both'),
+    )
     assert result == case['output']

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2587,10 +2587,12 @@ def unfurl_ref(ref, ignore_alt_text=False):
                 display_text = ref.split('|')[1]
             else:
                 url, desc = ref.split('|', 1)
-                if (config.unfurl_prevent_auto_linking and
-                        match_url = r"^\w+:(//)?{}$".format(re.escape(desc))
-                        re.match(match_url, url)):
+                match_url = r"^\w+:(//)?{}$".format(re.escape(desc))
+                url_matches_desc = re.match(match_url, url)
+                if url_matches_desc and config.unfurl_auto_link_display == "text":
                     display_text = desc
+                elif url_matches_desc and config.unfurl_auto_link_display == "url":
+                    display_text = url
                 else:
                     display_text = "{} ({})".format(url, desc)
     else:
@@ -3400,13 +3402,15 @@ class PluginConfig(object):
             desc='When displaying ("unfurling") links to channels/users/etc,'
             ' ignore the "alt text" present in the message and instead use the'
             ' canonical name of the thing being linked to.'),
-        'unfurl_prevent_auto_linking': Setting(
-            default='false',
+        'unfurl_auto_link_display': Setting(
+            default='both',
             desc='When displaying ("unfurling") links to channels/users/etc,'
-            ' only show the "alt text" if that is the same as the url without'
-            ' the protocol. This is useful because Slack inserts http:// in'
-            ' front of words containg dots and mailto: in front of email'
-            ' addresses, so this will remove it.'),
+            ' determine what is displayed when the text matches the url'
+            ' without the protocol. This happens when Slack automatically'
+            ' creates links, e.g. from words separated by dots or email'
+            ' addresses. Set it to "text" to only display the text written by'
+            ' the user, "url" to only display the url or "both" (the default)'
+            ' to display both.'),
         'unhide_buffers_with_activity': Setting(
             default='false',
             desc='When activity occurs on a buffer, unhide it even if it was'
@@ -3472,6 +3476,7 @@ class PluginConfig(object):
     get_render_italic_as = get_string
     get_slack_timeout = get_int
     get_thread_suffix_color = get_string
+    get_unfurl_auto_link_display = get_string
 
     def get_distracting_channels(self, key):
         return [x.strip() for x in w.config_get_plugin(key).split(',')]

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2587,7 +2587,12 @@ def unfurl_ref(ref, ignore_alt_text=False):
                 display_text = ref.split('|')[1]
             else:
                 url, desc = ref.split('|', 1)
-                display_text = "{} ({})".format(url, desc)
+                if (config.unfurl_prevent_auto_linking and
+                        match_url = r"^\w+:(//)?{}$".format(re.escape(desc))
+                        re.match(match_url, url)):
+                    display_text = desc
+                else:
+                    display_text = "{} ({})".format(url, desc)
     else:
         display_text = resolve_ref(ref)
     return display_text
@@ -3395,6 +3400,13 @@ class PluginConfig(object):
             desc='When displaying ("unfurling") links to channels/users/etc,'
             ' ignore the "alt text" present in the message and instead use the'
             ' canonical name of the thing being linked to.'),
+        'unfurl_prevent_auto_linking': Setting(
+            default='false',
+            desc='When displaying ("unfurling") links to channels/users/etc,'
+            ' only show the "alt text" if that is the same as the url without'
+            ' the protocol. This is useful because Slack inserts http:// in'
+            ' front of words containg dots and mailto: in front of email'
+            ' addresses, so this will remove it.'),
         'unhide_buffers_with_activity': Setting(
             default='false',
             desc='When activity occurs on a buffer, unhide it even if it was'


### PR DESCRIPTION
When you write multiple words separated by dots, or email adresses, Slack will turn those into links. Wee-slack will display this as `text (url)`, where url is just the text with http:// or mailto: prefixed. This makes the text hard to read, and might not even make sense (e.g. when writing server names or user@hostname).

When you receive such an url, the alt text of the url will be the original text. This means that we can check if the url is just the alt text with a protocol prefixed. If it is, we should just print the alt text and ignore the url.

I guess some people may want the urls, so they are able to click the links. And since it removes information coming from slack, I made it into an option instead of making it the default.