### PR TITLE
Switch to thread buffer on open if configured

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2981,6 +2981,8 @@ def thread_command_callback(data, current_buffer, args):
                 pm.thread_channel = tc
                 tc.open()
                 # tc.create_buffer()
+                if config.switch_buffer_on_join:
+                    w.buffer_set(tc.channel_buffer, "display", "1")
                 return w.WEECHAT_RC_OK_EAT
         elif args[0] == '/reply':
             count = int(args[1])


### PR DESCRIPTION
This fixes `/thread` to obey the `switch_buffer_on_join` setting.

Ref: #377