### PR TITLE
Add ability to open multiparty DMs with /query and /slack talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Join a channel:
 
 Start a direct chat with someone or multiple users:
 ```
-/query [username] ([username2] [username3]...)
-/slack talk [username] ([username2] [username3]...)
+/query <username>[,<username2>[,<username3>...]]
+/slack talk <username>[,<username2>[,<username3>...]]
 ```
 
 List channels:

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Join a channel:
 /join [channel]
 ```
 
-Start a direct chat with someone:
+Start a direct chat with someone or multiple users:
 ```
-/query [username]
-/slack talk [username]
+/query [username] ([username2] [username3]...)
+/slack talk [username] ([username2] [username3]...)
 ```
 
 List channels:


### PR DESCRIPTION
`command_talk` can now accept multiple arguments, which allows commands
like `/query user1 user2` to open a MPDM with user1 and user2.