### PR TITLE
Allow sending special messages by escaping them with / or \

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Run a Slack slash command. Simply prepend `/slack slash` to what you'd type in t
 /slack slash /desiredcommand arg1 arg2 arg3
 ```
 
+To send a command as a normal message instead of performing the action, prefix it with a slash or a space, like so:
+```
+//slack
+ s/a/b/
+```
+
 #### Threads
 
 Start a new thread on the most recent message The number indicates which message in the buffer to reply to, in reverse time order:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -644,7 +644,7 @@ def buffer_input_callback(signal, buffer_ptr, data):
     if not channel:
         return w.WEECHAT_RC_ERROR
 
-    reaction = re.match("^\s*(\d*)(\+|-):(.*):\s*$", data)
+    reaction = re.match("^(\d*)(\+|-):(.*):\s*$", data)
     substitute = re.match("^(\d*)s/", data)
     if reaction:
         if reaction.group(2) == "+":
@@ -664,6 +664,8 @@ def buffer_input_callback(signal, buffer_ptr, data):
             old = old.replace(r'\/', '/')
             channel.edit_nth_previous_message(msgno, old, new, flags)
     else:
+        if data.startswith(('//', ' ')):
+            data = data[1:]
         channel.send_message(data)
         # this is probably wrong channel.mark_read(update_remote=True, force=True)
     return w.WEECHAT_RC_OK


### PR DESCRIPTION
This allows you to send messages starting with / or messages like s/a/b/
and +:test: as normal text messages instead of performing the action
they normally would. This is done by prefixing the message with / or \,
and then the prefix character is removed from the resulting message.

Allowing / as a prefix, so you can write e.g. //slack is the normal way
to send messages starting with / in weechat. Using \ instead is added
for the other special messages (e.g. /+:test: is interpreted as a
command, so you have to write \+:test: instead). If you want to write a
message starting with \, just start it with \\.