### PR TITLE
Display nicklist in MPDM messages

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1515,7 +1515,7 @@ class SlackChannel(object):
     def update_nicklist(self, user=None):
         if not self.channel_buffer:
             return
-        if self.type not in ["channel", "group"]:
+        if self.type not in ["channel", "group", "mpim"]:
             return
         w.buffer_set(self.channel_buffer, "nicklist", "1")
         # create nicklists for the current channel if they don't exist


### PR DESCRIPTION
- Fix a regression from 95fa084893660b655388604084f082a080f1ba32 that disabled the nicklist in multi-person direct
  messages