### PR TITLE
Add option to disable sending typing notification to Slack

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3332,7 +3332,8 @@ def setup_hooks():
     w.hook_signal('buffer_switch', "buffer_switch_callback", "EVENTROUTER")
     w.hook_signal('window_switch', "buffer_switch_callback", "EVENTROUTER")
     w.hook_signal('quit', "quit_notification_cb", "")
-    w.hook_signal('input_text_changed', "typing_notification_cb", "")
+    if config.send_typing_notice:
+        w.hook_signal('input_text_changed', "typing_notification_cb", "")
 
     w.hook_command(
         # Command name and description
@@ -3455,6 +3456,10 @@ class PluginConfig(object):
             default='italic',
             desc='When receiving bold text from Slack, render it as this in weechat.'
             ' If your terminal lacks italic support, consider using "underline" instead.'),
+        'send_typing_notice': Setting(
+            default='true',
+            desc='Alert Slack users when you are typing a message in the input bar '
+            '(Requires reload)'),
         'server_aliases': Setting(
             default='',
             desc='A comma separated list of `subdomain:alias` pairs. The alias'


### PR DESCRIPTION
- Many IM clients that support alerting the receiving user that you're
  typing include an option to disable this behavior. This commit adds
  the `send_typing_notice` boolean option. When it is false
  `typing_notification_cb` is not registered for the
  `input_text_changed` Weechat signal. By default this option is
  true.

![](https://i.imgur.com/S8jnxvs.png)
https://xkcd.com/1886/
