### PR TITLE
Hilight team identifier in slack

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1268,7 +1268,7 @@ class SlackChannel(object):
     def set_highlights(self):
         # highlight my own name and any set highlights
         if self.channel_buffer:
-            highlights = self.team.highlight_words.union({'@' + self.team.nick, "!here", "!channel", "!everyone"})
+            highlights = self.team.highlight_words.union({'@' + self.team.nick, self.team.myidentifier, "!here", "!channel", "!everyone"})
             h_str = ",".join(highlights)
             w.buffer_set(self.channel_buffer, "highlight_words", h_str)
 


### PR DESCRIPTION
This adds a hilight on team identifier in Slack.

The reason is that the api sometimes gives those identifiers without "@" prefix, especially in case of hooks (the bug also appears on slack non-web clients).

Since the identifier is quite "unique" there is almost no risk of unwanted hilights