### PR TITLE
Allow query with @'es

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2992,6 +2992,8 @@ def command_talk(data, current_buffer, args):
     c = team.get_channel_map()
     if channel_name not in c:
         u = team.get_username_map()
+        if channel_name.startswith('@'):
+            channel_name = channel_name[1:]
         if channel_name in u:
             s = SlackRequest(team.token, "im.open", {"user": u[channel_name]}, team_hash=team.team_hash)
             EVENTROUTER.receive(s)


### PR DESCRIPTION
This allows /query to accept @username arguments as if they were username.

Since the completion command prefixes @, even in case of /query, it can help to allow those rather than being obliged to remove it manually