### PR TITLE
Restore OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Log in to Slack:
 /slack register
 ```
 
-This command opens your browser and prompts you to authorize WeeChat with Slack.
-Once you've accomplished this, copy the "code" portion of the URL in the browser
-and pass it to this command:
+This command prints a link you should open in your browser to authorize WeeChat
+with Slack. Once you've accomplished this, copy the "code" portion of the URL in
+the browser and pass it to this command:
 
 ```
 /slack register [YOUR_SLACK_TOKEN]

--- a/README.md
+++ b/README.md
@@ -88,10 +88,35 @@ weechat
 **NOTE:** If weechat is already running, the script can be loaded using ``/python load python/autoload/wee_slack.py``
 
 #### 4. Add your Slack API key(s)
+
+Log in to Slack:
+
+```
+/slack register
+```
+
+This command opens your browser and prompts you to authorize WeeChat with Slack.
+Once you've accomplished this, copy the "code" portion of the URL in the browser
+and pass it to this command:
+
+```
+/slack register [YOUR_SLACK_TOKEN]
+```
+
+Your Slack team is now added, and you can complete setup by restarting the
+wee-slack plugin.
+
+```
+/python reload slack
+```
+
+Alternatively, you can click the "Request token" button at the
+[Slack legacy token page](https://api.slack.com/custom-integrations/legacy-tokens),
+and paste it directly into your settings:
+
 ```
 /set plugins.var.python.slack.slack_api_token [YOUR_SLACK_TOKEN]
 ```
-^^ (find this at https://api.slack.com/custom-integrations/legacy-tokens using the "Request token" button)
 
 If you don't want to store your API token in plaintext you can use the secure features of weechat:
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2966,8 +2966,6 @@ def me_command_cb(data, current_buffer, args):
 
 
 def command_register(data, current_buffer, args):
-    e = EVENTROUTER
-    team = e.weechat_controller.buffers[current_buffer].team
     CLIENT_ID = "2468770254.51917335286"
     CLIENT_SECRET = "dcb7fe380a000cba0cca3169a5fe8d70"  # Not really a secret.
     if args == 'register':
@@ -2979,23 +2977,25 @@ def command_register(data, current_buffer, args):
             3) Click "Authorize" in the browser **IMPORTANT: the redirect will fail, this is expected**
             4) Copy the "code" portion of the URL to your clipboard
             5) Return to weechat and run `/slack register [code]`
-""")
-        team.buffer_prnt(message)
+        """)
+        w.prnt("", message)
         return
 
-    aargs = args.split(None, 2)
-    if len(aargs) != 2:
-        team.buffer_prnt("ERROR: invalid args to register")
+    try:
+        _, oauth_code = args.split()
+    except ValueError:
+        w.prnt("",
+               "ERROR: wrong number of arguments given for register command")
         return
 
     uri = (
         "https://slack.com/api/oauth.access?"
         "client_id={}&client_secret={}&code={}"
-    ).format(CLIENT_ID, CLIENT_SECRET, aargs[1])
+    ).format(CLIENT_ID, CLIENT_SECRET, oauth_code)
     ret = urllib.urlopen(uri).read()
     d = json.loads(ret)
     if not d["ok"]:
-        team.buffer_prnt(
+        w.prnt("",
             "ERROR: Couldn't get Slack OAuth token: {}".format(d['error']))
         return
 
@@ -3007,8 +3007,8 @@ def command_register(data, current_buffer, args):
         w.config_set_plugin('slack_api_token',
                             ','.join([tok, d['access_token']]))
 
-    team.buffer_prnt("Success! Added team \"%s\"" % (d['team_name'],))
-    team.buffer_prnt("Please reload wee-slack")
+    w.prnt("", "Success! Added team \"%s\"" % (d['team_name'],))
+    w.prnt("", "Please reload wee-slack with: /script reload slack")
 
 
 @slack_buffer_or_ignore

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2964,10 +2964,10 @@ def me_command_cb(data, current_buffer, args):
     return w.WEECHAT_RC_OK_EAT
 
 
-def command_register(current_buffer, args):
+def command_register(data, current_buffer, args):
     CLIENT_ID="2468770254.51917335286"
     CLIENT_SECRET="dcb7fe380a000cba0cca3169a5fe8d70" #this is not really a secret
-    if not args:
+    if args == 'register':
         message = """
 #### Retrieving a Slack token via OAUTH ####
 
@@ -2983,11 +2983,14 @@ def command_register(current_buffer, args):
         w.prnt(current_buffer, message)
     else:
         aargs = args.split(None, 2)
-        if len(aargs) <> 1:
+        if len(aargs) != 2:
             w.prnt(current_buffer, "ERROR: invalid args to register")
         else:
-            #w.prnt(current_buffer, "https://slack.com/api/oauth.access?client_id={}&client_secret={}&code={}".format(CLIENT_ID, CLIENT_SECRET, aargs[0]))
-            ret = urllib.urlopen("https://slack.com/api/oauth.access?client_id={}&client_secret={}&code={}".format(CLIENT_ID, CLIENT_SECRET, aargs[0])).read()
+            uri = (
+                "https://slack.com/api/oauth.access?"
+                "client_id={}&client_secret={}&code={}"
+            ).format(CLIENT_ID, CLIENT_SECRET, aargs[1])
+            ret = urllib.urlopen(uri).read()
             d = json.loads(ret)
             if d["ok"] == True:
                 w.prnt(current_buffer, "Success! Access token is: " + d['access_token'])

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2964,6 +2964,37 @@ def me_command_cb(data, current_buffer, args):
     return w.WEECHAT_RC_OK_EAT
 
 
+def command_register(current_buffer, args):
+    CLIENT_ID="2468770254.51917335286"
+    CLIENT_SECRET="dcb7fe380a000cba0cca3169a5fe8d70" #this is not really a secret
+    if not args:
+        message = """
+#### Retrieving a Slack token via OAUTH ####
+
+1) Paste this into a browser: https://slack.com/oauth/authorize?client_id=2468770254.51917335286&scope=client
+2) Select the team you wish to access from wee-slack in your browser.
+3) Click "Authorize" in the browser **IMPORTANT: the redirect will fail, this is expected**
+4) Copy the "code" portion of the URL to your clipboard
+5) Return to weechat and run `/slack register [code]`
+6) Add the returned token per the normal wee-slack setup instructions
+
+
+"""
+        w.prnt(current_buffer, message)
+    else:
+        aargs = args.split(None, 2)
+        if len(aargs) <> 1:
+            w.prnt(current_buffer, "ERROR: invalid args to register")
+        else:
+            #w.prnt(current_buffer, "https://slack.com/api/oauth.access?client_id={}&client_secret={}&code={}".format(CLIENT_ID, CLIENT_SECRET, aargs[0]))
+            ret = urllib.urlopen("https://slack.com/api/oauth.access?client_id={}&client_secret={}&code={}".format(CLIENT_ID, CLIENT_SECRET, aargs[0])).read()
+            d = json.loads(ret)
+            if d["ok"] == True:
+                w.prnt(current_buffer, "Success! Access token is: " + d['access_token'])
+            else:
+                w.prnt(current_buffer, "Failed! Error is: " + d['error'])
+
+
 @slack_buffer_or_ignore
 @utf8_decode
 def msg_command_cb(data, current_buffer, args):


### PR DESCRIPTION
Partly addresses #135. This restores some OAuth logic that was lost in a large merge, and it updates the lost logic to be compatible with the latest wee-slack code.

The old logic had simply printed the Slack token to the buffer. I added a new feature: the new logic now automatically appends the token to the "plugins.var.python.slack.slack_api_token" setting and tells the user to restart weechat.

There are two more missing features after this which I propose to add:

1. Fix the OAuth redirect failure. Open a local webserver listening on a random available port, then include the `redirect_uri` parameter to redirect the auth flow back to localhost (if possible, this'll require research and maybe help from you to configure the wee-slack app on slack.com)
2. Update the `config_changed` callback to reload teams if the slack_api_token setting has changed