### PR TITLE
Don't add deleted users to the nicklist

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1557,6 +1557,8 @@ class SlackChannel(object):
 
         if user and len(self.members) < 1000:
             user = self.team.users[user]
+            if user.deleted:
+                return
             nick = w.nicklist_search_nick(self.channel_buffer, "", user.name)
             # since this is a change just remove it regardless of where it is
             w.nicklist_remove_nick(self.channel_buffer, nick)


### PR DESCRIPTION
This check was done when generating complete nicklist, but not when
updating a single user. Deleted users are still part of the member list
of a channel, if they don't leave the channel first. This caused a
deleted user to be inserted into the nicklist when processing a joined
channel message or when receiving a presence change for that user.

When investigating this, I saw that we still receive presence change
events for deleted users if we subscribe to them. We might want to
filter out the deleted users when generating the list of users to
subscribe to.