### PR TITLE
Add explicit_changes setting causing modifications to trigger explicit updates

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1418,6 +1418,7 @@ class SlackChannel(object):
 
     def change_message(self, ts, text=None, suffix=None):
         ts = SlackTS(ts)
+        m = None
         if ts in self.messages:
             m = self.messages[ts]
             if text:
@@ -1425,7 +1426,11 @@ class SlackChannel(object):
             if suffix:
                 m.change_suffix(suffix)
             text = m.render(force=True)
-        modify_buffer_line(self.channel_buffer, text, ts.major, ts.minor)
+        extended_result = {}
+        modify_buffer_line(self.channel_buffer, text, ts.major, ts.minor, extended_result)
+        if config.explicit_changes and extended_result['matching_lines'] > 0 and m is not None:
+            self.buffer_print(m.sender, text + (' (mod #%d)' % extended_result['line_number']), ts)
+            
         return True
 
     def edit_nth_previous_message(self, n, old, new, flags):
@@ -2843,7 +2848,7 @@ def create_reaction_string(reactions):
     return reaction_string
 
 
-def modify_buffer_line(buffer, new_line, timestamp, time_id):
+def modify_buffer_line(buffer, new_line, timestamp, time_id, extended_result = {}):
     # get a pointer to this buffer's lines
     own_lines = w.hdata_pointer(w.hdata_get('buffer'), buffer, 'own_lines')
     if own_lines:
@@ -2854,6 +2859,9 @@ def modify_buffer_line(buffer, new_line, timestamp, time_id):
         struct_hdata_line_data = w.hdata_get('line_data')
         # keep track of the number of lines with the matching time and id
         number_of_matching_lines = 0
+        # line_number to return
+        extended_result['line_number'] = 1
+        extended_result['matching_lines'] = 0
 
         while line_pointer:
             # get a pointer to the data in line_pointer via layout of struct_hdata_line
@@ -2865,6 +2873,7 @@ def modify_buffer_line(buffer, new_line, timestamp, time_id):
 
                 if timestamp == int(line_timestamp) and int(time_id) == line_time_id:
                     number_of_matching_lines += 1
+                    extended_result['matching_lines'] = number_of_matching_lines
                 elif number_of_matching_lines > 0:
                     # since number_of_matching_lines is non-zero, we have
                     # already reached the message and can stop traversing
@@ -2875,6 +2884,7 @@ def modify_buffer_line(buffer, new_line, timestamp, time_id):
                 return w.WEECHAT_RC_ERROR
             # move backwards one line and try again - exit the while if you hit the end
             line_pointer = w.hdata_move(struct_hdata_line, line_pointer, -1)
+            extended_result['line_number'] += 1
 
         # split the message into at most the number of existing lines
         lines = new_line.split('\n', number_of_matching_lines - 1)
@@ -3636,6 +3646,10 @@ class PluginConfig(object):
         'distracting_channels': Setting(
             default='',
             desc='List of channels to hide.'),
+        'explicit_changes': Setting(
+            default='false',
+            desc='Explicitly add lines to buffer for all changes (edits,'
+            ' reactions, etc.)  Useful for logging and relay clients.'),
         'group_name_prefix': Setting(
             default='&',
             desc='The prefix of buffer names for groups (private channels).'),


### PR DESCRIPTION
Background:

I am using weechat through a relay (weechat.el using the weechat
protocol).  I also keep logs using the standard weechat mechanism.

Neither of these methods capture a message being edited, a thread
being created, etc.  They are just completely silent on it.

It would be nice to have an option that would disable features that
edit history, and instead add new lines to the buffer ("Thread a8f
created for message 3", "Message 4 edited to: xxxx", etc).  I wouldn't
mind seeing reactions this way either, though that could be annoying
to some.

This accomplishes that.