### PR TITLE
Add support to disable teammate link previews

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2745,6 +2745,8 @@ def unhtmlescape(text):
 
 
 def unwrap_attachments(message_json, text_before):
+    if 'user' in message_json and not config.link_previews:
+        return ''
     text_before_unescaped = unhtmlescape(text_before)
     attachment_texts = []
     a = message_json.get("attachments", None)
@@ -3639,6 +3641,9 @@ class PluginConfig(object):
         'group_name_prefix': Setting(
             default='&',
             desc='The prefix of buffer names for groups (private channels).'),
+        'link_previews': Setting(
+            default='true',
+            desc='Show previews of website content linked by teammates.'),
         'map_underline_to': Setting(
             default='_',
             desc='When sending underlined text to slack, use this formatting'


### PR DESCRIPTION
This PR introduces a new config option, `plugins.var.python.slack.link_previews`, set to `true` by default.
* With the default `true` setting, wee-slack works as it does today.
* Disabling this setting (`false`, `off`, etc.) will disable link previews of URLs pasted by teammates. It does not affect previews or disable displaying additional attachment content from bots, services, server notices, etc. The setting will affect new incoming messages, or will be retroactively applied if you `/script reload slack`, `/python reload`, or restart weechat.

Fixes #526.

This isn't the whitelist/blacklist functionality that the Slack web UI has, but it's a start! The values of the setting could be changed to a comma-delimited list of domains that would be whitelisted, or blacklisted if prefixed by a `!`, perhaps.