### PR TITLE
Fix typing indicator when having multiple windows

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -780,13 +780,12 @@ def slack_never_away_cb(data, remaining_calls):
 
 
 @utf8_decode
-def typing_bar_item_cb(data, current_buffer, args):
+def typing_bar_item_cb(data, item, current_window, current_buffer, extra_info):
     """
     Privides a bar item indicating who is typing in the current channel AND
     why is typing a DM to you globally.
     """
     typers = []
-    current_buffer = w.current_buffer()
     current_channel = EVENTROUTER.weechat_controller.buffers.get(current_buffer, None)
 
     # first look for people typing in this channel
@@ -3520,7 +3519,7 @@ def load_emoji():
 def setup_hooks():
     cmds = {k[8:]: v for k, v in globals().items() if k.startswith("command_")}
 
-    w.bar_item_new('slack_typing_notice', 'typing_bar_item_cb', '')
+    w.bar_item_new('slack_typing_notice', '(extra)typing_bar_item_cb', '')
 
     w.hook_timer(1000, 0, 0, "typing_update_cb", "")
     w.hook_timer(1000, 0, 0, "buffer_list_update_callback", "EVENTROUTER")


### PR DESCRIPTION
If you have multiple windows in weechat, you get (by default) one typing
bar per window. Previously, the bar used the globally active channel
(the active channel in the active window) for all the bars, so all the
bars would show the same info. This changes it to use the active channel
for the window the bar is in.

The callback name is changed to include (extra), as that is necessary
for getting the active buffer for each window as an argument to the
callback function.