### PR TITLE
Fix channels not being marked as read when latest message is in a thread

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1524,7 +1524,7 @@ class SlackChannel(object):
 
     def mark_read(self, ts=None, update_remote=True, force=False):
         if not ts:
-            ts = next(self.main_message_keys_reversed(), SlackTS())
+            ts = next(reversed(self.messages), SlackTS())
         if self.new_messages or force:
             if self.channel_buffer:
                 w.buffer_set(self.channel_buffer, "unread", "")


### PR DESCRIPTION
`SlackChannel.mark_read` was only looking at non-thread messages when
determining the latest timestamp to use, so thread messages past that
weren't included. They were then still counted in `unread_count_display`
from the `.info` API methods, and channels with them would always appear
unread on startup.