### PR TITLE
resolved issue #552

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3434,7 +3434,7 @@ def command_back(data, current_buffer, args):
     /slack back
     """
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
-    s = SlackRequest(team.token, "presence.set", {"presence": "active"}, team_hash=team.team_hash)
+    s = SlackRequest(team.token, "presence.set", {"presence": "auto"}, team_hash=team.team_hash)
     EVENTROUTER.receive(s)
 
 


### PR DESCRIPTION
Should set the presence.set status to _auto_ instead of _active_.
Based on the slack documentation, there is no way to set the status to active directly.

https://api.slack.com/docs/presence-and-status

**Manual Away**
An application can call users.setPresence to manually mark a user as _away_ or _auto_. A manual status set using this method will persist between connections.

A manual away status set using this method overrides the automatic presence determined by the message server.

Setting presence back to auto indicates that the automatic status should be used instead. There's no way to force a user status to _active_.