### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
+
 install:
   - 'pip install websocket-client pytest'
 

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import pytest
 import sys
@@ -18,7 +19,7 @@ class fakewebsocket(object):
     def recv(self):
         return json.dumps(self.returndata.pop(0))
     def send(self, data):
-        print "websocket received: {}".format(data)
+        print("websocket received: {}".format(data))
         return
 
 @pytest.fixture
@@ -61,7 +62,7 @@ class FakeWeechat():
         for arg in args:
             if arg != None:
                 output += "{}, ".format(arg)
-        print "w.prnt {}".format(output)
+        print("w.prnt {}".format(output))
     def hdata_get(*args):
         return "0x000001"
     def hdata_pointer(*args):

--- a/_pytest/test_eventrouter.py
+++ b/_pytest/test_eventrouter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 from wee_slack import EventRouter, ProcessNotImplemented, SlackRequest
 
@@ -35,15 +36,15 @@ def test_EventRouterReceivedata(mock_weechat):
 
     e = EventRouter()
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, -1, ' {"JSON": "MEH", ', 4)
     #print len(e.reply_buffer)
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, -1, ' "JSON2": "MEH", ', 4)
     #print len(e.reply_buffer)
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, 0, ' "JSON3": "MEH"}', 4)
     #print len(e.reply_buffer)
     try:
@@ -54,7 +55,7 @@ def test_EventRouterReceivedata(mock_weechat):
     except:
         pass
 
-    print e.context
+    print(e.context)
     #assert False
 
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.start", {"meh": "blah"}))

--- a/_pytest/test_everything.py
+++ b/_pytest/test_everything.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import glob
 import json
 
@@ -19,17 +20,17 @@ def test_everything(realish_eventrouter, mock_websocket):
 
     datafiles = glob.glob("_pytest/data/websocket/*.json")
 
-    print datafiles
+    print(datafiles)
     #assert False
 
     notimplemented = set()
 
     for fname in datafiles:
         try:
-            print "####################"
+            print("####################")
             data = json.loads(open(fname, 'r').read())
             socket.add(data)
-            print data
+            print(data)
             eventrouter.receive_ws_callback(t)
             eventrouter.handle_next()
         except ProcessNotImplemented as e:
@@ -39,11 +40,11 @@ def test_everything(realish_eventrouter, mock_websocket):
             pass
 
     if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
+        print("####################")
+        print(sorted(notimplemented))
+        print("####################")
 
-    print len(eventrouter.queue)
+    print(len(eventrouter.queue))
     #assert False
 
 

--- a/_pytest/test_processreply.py
+++ b/_pytest/test_processreply.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #from wee_slack import process_reply
 
 def test_process_reply(realish_eventrouter, mock_websocket):
@@ -20,7 +21,7 @@ def test_process_reply(realish_eventrouter, mock_websocket):
     socket = mock_websocket
     socket.add({"reply_to": 1, "_team": t, "ts": "12341234.111"})
 
-    print e.teams[t].ws_replies
+    print(e.teams[t].ws_replies)
 
     e.receive_ws_callback(t)
     e.handle_next()

--- a/_pytest/test_processteamjoin.py
+++ b/_pytest/test_processteamjoin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import glob
 import json
 
@@ -23,17 +24,17 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
 
     datafiles = glob.glob("_pytest/data/websocket/1485975606.59-team_join.json")
 
-    print datafiles
+    print(datafiles)
     #assert False
 
     notimplemented = set()
 
     for fname in datafiles:
         try:
-            print "####################"
+            print("####################")
             data = json.loads(open(fname, 'r').read())
             socket.add(data)
-            print data
+            print(data)
             eventrouter.receive_ws_callback(t)
             eventrouter.handle_next()
         except ProcessNotImplemented as e:
@@ -43,9 +44,9 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
             pass
 
     if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
+        print("####################")
+        print(sorted(notimplemented))
+        print("####################")
 
     #print len(eventrouter.queue)
     assert len(eventrouter.teams[t].users) == 4

--- a/_pytest/test_sendmessage.py
+++ b/_pytest/test_sendmessage.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 def test_send_message(realish_eventrouter, mock_websocket):
     e = realish_eventrouter
@@ -16,6 +17,6 @@ def test_send_message(realish_eventrouter, mock_websocket):
     channel = e.teams[t].channels[c]
     channel.send_message('asdf')
 
-    print c
+    print(c)
 
     #assert False

--- a/_pytest/test_slackchannel.py
+++ b/_pytest/test_slackchannel.py
@@ -1,33 +1,34 @@
+from __future__ import print_function
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['C3ZEQAYN7']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 
-    print "-------"
-    print c == "random"
-    print "-------"
-    print c == "#random"
-    print "-------"
-    print c == "weeslacktest.slack.com.#random"
-    print "-------"
-    print c == "weeslacktest.slack.com.random"
-    print "-------"
-    print c == "dandom"
+    print("-------")
+    print(c == "random")
+    print("-------")
+    print(c == "#random")
+    print("-------")
+    print(c == "weeslacktest.slack.com.#random")
+    print("-------")
+    print(c == "weeslacktest.slack.com.random")
+    print("-------")
+    print(c == "dandom")
 
-    print e.weechat_controller.buffers
+    print(e.weechat_controller.buffers)
     #assert False

--- a/_pytest/test_slackdmchannel.py
+++ b/_pytest/test_slackdmchannel.py
@@ -1,20 +1,21 @@
+from __future__ import print_function
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackDMChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['D3ZEQULHZ']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackgroupchannel.py
+++ b/_pytest/test_slackgroupchannel.py
@@ -1,20 +1,21 @@
+from __future__ import print_function
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackGroupChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['G3ZJKP7GA']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackmpdmchannel.py
+++ b/_pytest/test_slackmpdmchannel.py
@@ -1,20 +1,21 @@
+from __future__ import print_function
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackMPDMChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['G3ZGMF4RZ']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackrequest.py
+++ b/_pytest/test_slackrequest.py
@@ -1,8 +1,9 @@
+from __future__ import print_function
 from wee_slack import SlackRequest, EventRouter
 
 def test_SlackRequest():
     s = SlackRequest('xoxoxoxox', "blah.get", {"meh": "blah"})
-    print s
+    print(s)
 
     e = EventRouter()
     e.receive(s)

--- a/_pytest/test_utf8_helpers.py
+++ b/_pytest/test_utf8_helpers.py
@@ -23,19 +23,23 @@ def test_decode_preserves_iterable_type():
     assert type(value_tuple) == type(decode_from_utf8(value_tuple))
 
 def test_decodes_utf8_string_to_unicode():
-    assert u'æøå' == decode_from_utf8(b'æøå')
+    assert u'æøå' == decode_from_utf8(b'æøå')  # noqa
 
 def test_decodes_utf8_dict_to_unicode():
-    assert {u'æ': u'å', u'ø': u'å'} == decode_from_utf8({b'æ': b'å', b'ø': b'å'})
+    assert {u'æ': u'å', u'ø': u'å'} == decode_from_utf8({b'æ': b'å', b'ø': b'å'})  # noqa
 
 def test_decodes_utf8_list_to_unicode():
-    assert [u'æ', u'ø', u'å'] == decode_from_utf8([b'æ', b'ø', b'å'])
+    assert [u'æ', u'ø', u'å'] == decode_from_utf8([b'æ', b'ø', b'å'])  # noqa
 
 def test_encode_preserves_string_without_utf8():
     assert b'test' == encode_to_utf8(u'test')
 
 def test_encode_preserves_byte_strings():
-    assert b'æøå' == encode_to_utf8(b'æøå')
+    try:
+        unicode        # Python 2
+        assert b'æøå' == encode_to_utf8(b'æøå')  # noqa
+    except NameError:  # Python 3
+        pass
 
 def test_encode_preserves_mapping_type():
     value_dict = {'a': 'x', 'b': 'y', 'c': 'z'}
@@ -50,21 +54,21 @@ def test_encode_preserves_iterable_type():
     assert type(value_tuple) == type(encode_to_utf8(value_tuple))
 
 def test_encodes_utf8_string_to_unicode():
-    assert b'æøå' == encode_to_utf8(u'æøå')
+    assert b'æøå' == encode_to_utf8(u'æøå')  # noqa
 
 def test_encodes_utf8_dict_to_unicode():
-    assert {b'æ': b'å', b'ø': b'å'} == encode_to_utf8({u'æ': u'å', u'ø': u'å'})
+    assert {b'æ': b'å', b'ø': b'å'} == encode_to_utf8({u'æ': u'å', u'ø': u'å'})  # noqa
 
 def test_encodes_utf8_list_to_unicode():
-    assert [b'æ', b'ø', b'å'] == encode_to_utf8([u'æ', u'ø', u'å'])
+    assert [b'æ', b'ø', b'å'] == encode_to_utf8([u'æ', u'ø', u'å'])  # noqa
 
 @utf8_decode
 def method_with_utf8_decode(*args, **kwargs):
     return (args, kwargs)
 
 def test_utf8_decode():
-    args = (b'æ', b'ø', b'å')
-    kwargs = {b'æ': b'å', b'ø': b'å'}
+    args = (b'æ', b'ø', b'å')  # noqa
+    kwargs = {b'æ': b'å', b'ø': b'å'}  # noqa
 
     result_args, result_kwargs = method_with_utf8_decode(*args, **kwargs)
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from collections import OrderedDict
 from functools import wraps
@@ -30,8 +31,14 @@ from websocket import create_connection, WebSocketConnectionClosedException
 # hack to make tests possible.. better way?
 try:
     import weechat
-except:
+except ImportError:
     pass
+
+try:
+    basestring     # Python 2
+    unicode
+except NameError:  # Python 3
+    basestring = unicode = str
 
 SCRIPT_NAME = "slack"
 SCRIPT_AUTHOR = "Ryan Huber <rhuber@gmail.com>"
@@ -1143,7 +1150,7 @@ class SlackTeam(object):
             self.ws.send(encode_to_utf8(message))
             dbg("Sent {}...".format(message[:100]))
         except:
-            print "WS ERROR"
+            print("WS ERROR")
             dbg("Unexpected error: {}\nSent: {}".format(sys.exc_info()[0], data))
             self.set_connected()
 
@@ -3588,7 +3595,8 @@ def dbg(message, level=0, main_buffer=False, fout=False):
         global debug_string
         message = "DEBUG: {}".format(message)
         if fout:
-            file('/tmp/debug.log', 'a+').writelines(message + '\n')
+            with open('/tmp/debug.log', 'a+') as log_file:
+                log_file.writelines(message + '\n')
         if main_buffer:
                 # w.prnt("", "---------")
                 w.prnt("", "slack: " + message)
@@ -3824,9 +3832,9 @@ def trace_calls(frame, event, arg):
     caller = frame.f_back
     caller_line_no = caller.f_lineno
     caller_filename = caller.f_code.co_filename
-    print >> f, 'Call to %s on line %s of %s from line %s of %s' % \
+    print('Call to %s on line %s of %s from line %s of %s' % \
         (func_name, func_line_no, func_filename,
-         caller_line_no, caller_filename)
+         caller_line_no, caller_filename), file=f)
     f.flush()
     return
 


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run futurize --stage1 http://python-future.org/futurize_cheatsheet.html
* Define __basestring__ and __unicode__ in Python 3.
* Modify Travis CI to start running Python 3 tests in __allow_failures__ mode.

Ready for review. Python 3 syntax compatibility does not mean that the port is complete.