### PR TITLE
Use flake8 to find undefined names

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+select = E901,E999,F821,F822,F823
+count = True
+max-complexity = 10
+max-line-length = 120
+show-source = True
+statistics = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: python
 python:
   - "2.7"
-install:
-  - 'pip install websocket-client pytest'
+cache: pip
 
-script: python -m pytest
+install:
+  - pip install flake8 pytest websocket-client
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 .
+  # exit-zero treats all errors as warnings.
+  - flake8 . --exit-zero --select=C,E,F,W
+
+script:
+  - python -m pytest
 
 notifications:
   irc: "chat.freenode.net#wee-slack-dev"


### PR DESCRIPTION
__flake8__ tests currently flag __server__ as an undefined name twice in __wee_slack.py__.  Undefined names can raise a __NameError__ at runtime.  This PR adds flake8 testing to our Travis test runs.  ~~This PR will continue to fail until the two undefined names below are resolved.~~

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./wee_slack.py:3316:13: F821 undefined name 'server'
            server.buffer_prnt("Usage: /slack slash /someslashcommand [arguments...].")
            ^
./wee_slack.py:3417:13: F821 undefined name 'server'
            server.buffer_prnt("Usage: /slack status [status emoji] [status text].")
            ^
2     F821 undefined name 'server'
```