### PR TITLE
Minor formatting fixes

### DIFF
--- a/_pytest/test_formatting.py
+++ b/_pytest/test_formatting.py
@@ -12,3 +12,16 @@ import wee_slack
 ])
 def test_does_not_format(text):
     assert wee_slack.render_formatting(text) == text
+
+
+@pytest.mark.parametrize("text", [
+    "`hello *bar*`",
+    "`*`",
+    "`* *`",
+    "`* * *`",
+    "`* * * *`",
+    "`* * * * *`",
+    "`* * * * * *`",
+])
+def test_preserves_format_chars_in_code(text):
+    assert wee_slack.render_formatting(text) == text

--- a/_pytest/test_formatting.py
+++ b/_pytest/test_formatting.py
@@ -1,0 +1,14 @@
+import pytest
+
+import wee_slack
+
+
+@pytest.mark.parametrize("text", [
+    """
+    * an item
+    * another item
+    """,
+    "* Run this command: `find . -name '*.exe'`",
+])
+def test_does_not_format(text):
+    assert wee_slack.render_formatting(text) == text

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2600,11 +2600,11 @@ def process_emoji_changed(message_json, eventrouter, **kwargs):
 ###### New module/global methods
 
 def render_formatting(text):
-    text = re.sub(r'(^| )\*([^*\n]+)\*([^a-zA-Z0-9_]|$)',
+    text = re.sub(r'(^| )\*([^*\n`]+)\*([^a-zA-Z0-9_]|$)',
                   r'\1{}*\2*{}\3'.format(w.color(config.render_bold_as),
                                        w.color('-' + config.render_bold_as)),
                   text)
-    text = re.sub(r'(^| )_([^_\n]+)_([^a-zA-Z0-9_]|$)',
+    text = re.sub(r'(^| )_([^_\n`]+)_([^a-zA-Z0-9_]|$)',
                   r'\1{}_\2_{}\3'.format(w.color(config.render_italic_as),
                                        w.color('-' + config.render_italic_as)),
                   text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2600,11 +2600,11 @@ def process_emoji_changed(message_json, eventrouter, **kwargs):
 ###### New module/global methods
 
 def render_formatting(text):
-    text = re.sub(r'(^| )\*([^*]+)\*([^a-zA-Z0-9_]|$)',
+    text = re.sub(r'(^| )\*([^*\n]+)\*([^a-zA-Z0-9_]|$)',
                   r'\1{}\2{}\3'.format(w.color(config.render_bold_as),
                                        w.color('-' + config.render_bold_as)),
                   text)
-    text = re.sub(r'(^| )_([^_]+)_([^a-zA-Z0-9_]|$)',
+    text = re.sub(r'(^| )_([^_\n]+)_([^a-zA-Z0-9_]|$)',
                   r'\1{}\2{}\3'.format(w.color(config.render_italic_as),
                                        w.color('-' + config.render_italic_as)),
                   text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2601,11 +2601,11 @@ def process_emoji_changed(message_json, eventrouter, **kwargs):
 
 def render_formatting(text):
     text = re.sub(r'(^| )\*([^*\n]+)\*([^a-zA-Z0-9_]|$)',
-                  r'\1{}\2{}\3'.format(w.color(config.render_bold_as),
+                  r'\1{}*\2*{}\3'.format(w.color(config.render_bold_as),
                                        w.color('-' + config.render_bold_as)),
                   text)
     text = re.sub(r'(^| )_([^_\n]+)_([^a-zA-Z0-9_]|$)',
-                  r'\1{}\2{}\3'.format(w.color(config.render_italic_as),
+                  r'\1{}_\2_{}\3'.format(w.color(config.render_italic_as),
                                        w.color('-' + config.render_italic_as)),
                   text)
     return text


### PR DESCRIPTION
First and foremost, this prevents formatting going across newlines. Consider this example message:
```markdown
* an item
* another item
```

Clearly, `an item` should not be made bold. Slack doesn't.

This also preserves the original typed message, with `*_formatting_*` characters galore, for a few reasons:
* as a quick fix for #566 until we fix that properly, and
* Slack preserves formatting characters when copy-pasting.

This also prevents formatting going across backticks, such as in the following example:
```markdown
* Run this command: `find . -name '*.exe'`
```