### PR TITLE
Minimally-invasive (part of) Python 3 compatibility

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -54,9 +54,8 @@ class FakeWeechat():
     WEECHAT_RC_ERROR = 0
     WEECHAT_RC_OK = 1
     WEECHAT_RC_OK_EAT = 2
-
     def __init__(self):
-        pass
+        self.config = {}
         #print("INITIALIZE FAKE WEECHAT")
     def prnt(*args):
         output = "("
@@ -77,9 +76,11 @@ class FakeWeechat():
     def prefix(self, type):
         return ""
     def config_get_plugin(self, key):
-        return ""
+        return self.config.get(key, "")
     def config_get(self, key):
         return ""
+    def config_set_plugin(self, key, value):
+        self.config[key] = value
     def config_string(self, key):
         return ""
     def color(self, name):

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -31,7 +31,7 @@ def mock_websocket():
 def realish_eventrouter(mock_weechat):
     e = EventRouter()
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.start", {"meh": "blah"}))
-    rtmstartdata = open('_pytest/data/http/rtm.start.json', 'r').read()
+    rtmstartdata = open('_pytest/data/http/rtm.start.json', 'r').read().decode('utf-8')
     e.receive_httprequest_callback(context, 1, 0, rtmstartdata, 4)
     while len(e.queue):
         e.handle_next()

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 import pytest
 import sys
@@ -18,7 +20,7 @@ class fakewebsocket(object):
     def recv(self):
         return json.dumps(self.returndata.pop(0))
     def send(self, data):
-        print "websocket received: {}".format(data)
+        print("websocket received: {}".format(data))
         return
 
 @pytest.fixture
@@ -55,13 +57,13 @@ class FakeWeechat():
 
     def __init__(self):
         pass
-        #print "INITIALIZE FAKE WEECHAT"
+        #print("INITIALIZE FAKE WEECHAT")
     def prnt(*args):
         output = "("
         for arg in args:
             if arg != None:
                 output += "{}, ".format(arg)
-        print "w.prnt {}".format(output)
+        print("w.prnt {}".format(output))
     def hdata_get(*args):
         return "0x000001"
     def hdata_pointer(*args):
@@ -85,7 +87,7 @@ class FakeWeechat():
     def __getattr__(self, name):
         def method(*args):
             pass
-            #print "called {}".format(name)
+            #print("called {}".format(name))
             #if args:
             #    print "\twith args: {}".format(args)
         return method

--- a/_pytest/test_eventrouter.py
+++ b/_pytest/test_eventrouter.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pytest
 from wee_slack import EventRouter, ProcessNotImplemented, SlackRequest
 
@@ -35,17 +37,17 @@ def test_EventRouterReceivedata(mock_weechat):
 
     e = EventRouter()
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, -1, ' {"JSON": "MEH", ', 4)
-    #print len(e.reply_buffer)
+    #print(len(e.reply_buffer))
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, -1, ' "JSON2": "MEH", ', 4)
-    #print len(e.reply_buffer)
+    #print(len(e.reply_buffer))
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
-    print context
+    print(context)
     e.receive_httprequest_callback(context, 1, 0, ' "JSON3": "MEH"}', 4)
-    #print len(e.reply_buffer)
+    #print(len(e.reply_buffer))
     try:
         e.handle_next()
         e.handle_next()
@@ -54,7 +56,7 @@ def test_EventRouterReceivedata(mock_weechat):
     except:
         pass
 
-    print e.context
+    print(e.context)
     #assert False
 
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.start", {"meh": "blah"}))
@@ -63,18 +65,18 @@ def test_EventRouterReceivedata(mock_weechat):
     e.receive_httprequest_callback(context, 1, 0, rtmstartdata[5000:], 4)
     e.handle_next()
 
-    #print len(e.reply_buffer)
+    #print(len(e.reply_buffer))
 
-    #print e.teams
+    #print(e.teams)
 
     for t in e.teams:
-        #print vars(e.teams[t])
+        #print(vars(e.teams[t]))
         for c in e.teams[t].channels:
             pass
-            #print c
+            #print(c)
         for u in e.teams[t].users:
             pass
-            #print vars(u)
+            #print(vars(u))
 
 
 #    e = EventRouter()

--- a/_pytest/test_eventrouter.py
+++ b/_pytest/test_eventrouter.py
@@ -38,15 +38,15 @@ def test_EventRouterReceivedata(mock_weechat):
     e = EventRouter()
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
     print(context)
-    e.receive_httprequest_callback(context, 1, -1, ' {"JSON": "MEH", ', 4)
+    e.receive_httprequest_callback(context, 1, -1, u' {"JSON": "MEH", ', 4)
     #print(len(e.reply_buffer))
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
     print(context)
-    e.receive_httprequest_callback(context, 1, -1, ' "JSON2": "MEH", ', 4)
+    e.receive_httprequest_callback(context, 1, -1, u' "JSON2": "MEH", ', 4)
     #print(len(e.reply_buffer))
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.startold", {"meh": "blah"}))
     print(context)
-    e.receive_httprequest_callback(context, 1, 0, ' "JSON3": "MEH"}', 4)
+    e.receive_httprequest_callback(context, 1, 0, u' "JSON3": "MEH"}', 4)
     #print(len(e.reply_buffer))
     try:
         e.handle_next()
@@ -60,7 +60,7 @@ def test_EventRouterReceivedata(mock_weechat):
     #assert False
 
     context = e.store_context(SlackRequest('xoxoxoxox', "rtm.start", {"meh": "blah"}))
-    rtmstartdata = open('_pytest/data/http/rtm.start.json', 'r').read()
+    rtmstartdata = open('_pytest/data/http/rtm.start.json', 'r').read().decode('utf-8')
     e.receive_httprequest_callback(context, 1, -1, rtmstartdata[:5000], 4)
     e.receive_httprequest_callback(context, 1, 0, rtmstartdata[5000:], 4)
     e.handle_next()

--- a/_pytest/test_everything.py
+++ b/_pytest/test_everything.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import glob
 import json
 
@@ -12,24 +14,24 @@ def test_everything(realish_eventrouter, mock_websocket):
     #u = eventrouter.teams[t].users.keys()[0]
 
     #user = eventrouter.teams[t].users[u]
-    #print user
+    #print(user)
 
     socket = mock_websocket
     eventrouter.teams[t].ws = socket
 
     datafiles = glob.glob("_pytest/data/websocket/*.json")
 
-    print datafiles
+    print(datafiles)
     #assert False
 
     notimplemented = set()
 
     for fname in datafiles:
         try:
-            print "####################"
+            print("####################")
             data = json.loads(open(fname, 'r').read())
             socket.add(data)
-            print data
+            print(data)
             eventrouter.receive_ws_callback(t)
             eventrouter.handle_next()
         except ProcessNotImplemented as e:
@@ -39,11 +41,11 @@ def test_everything(realish_eventrouter, mock_websocket):
             pass
 
     if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
+        print("####################")
+        print(sorted(notimplemented))
+        print("####################")
 
-    print len(eventrouter.queue)
+    print(len(eventrouter.queue))
     #assert False
 
 

--- a/_pytest/test_process_message.py
+++ b/_pytest/test_process_message.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 
 from wee_slack import render
@@ -10,7 +12,7 @@ def test_process_message(realish_eventrouter, mock_websocket):
     u = e.teams[t].users.keys()[0]
 
     user = e.teams[t].users[u]
-    #print user
+    #print(user)
 
     socket = mock_websocket
     e.teams[t].ws = socket

--- a/_pytest/test_processreply.py
+++ b/_pytest/test_processreply.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 #from wee_slack import process_reply
 
 def test_process_reply(realish_eventrouter, mock_websocket):
@@ -8,7 +10,7 @@ def test_process_reply(realish_eventrouter, mock_websocket):
     #u = e.teams[t].users.keys()[0]
 
     #user = e.teams[t].users[u]
-    #print user
+    #print(user)
 
     socket = mock_websocket
     e.teams[t].ws = socket
@@ -20,14 +22,14 @@ def test_process_reply(realish_eventrouter, mock_websocket):
     socket = mock_websocket
     socket.add({"reply_to": 1, "_team": t, "ts": "12341234.111"})
 
-    print e.teams[t].ws_replies
+    print(e.teams[t].ws_replies)
 
     e.receive_ws_callback(t)
     e.handle_next()
 
     #reply = {"reply_to": 1, "_team": t, "ts": "12341234.111"}
-    #print reply
+    #print(reply)
     #process_reply(reply, e)
-    #print e.teams[t].ws_replies
+    #print(e.teams[t].ws_replies)
     #assert False
     pass

--- a/_pytest/test_processteamjoin.py
+++ b/_pytest/test_processteamjoin.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import glob
 import json
 
@@ -11,7 +13,7 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
     #u = eventrouter.teams[t].users.keys()[0]
 
     #user = eventrouter.teams[t].users[u]
-    #print user
+    #print(user)
 
     #delete charles so we can add him
     del eventrouter.teams[t].users['U4096CBHC']
@@ -23,17 +25,17 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
 
     datafiles = glob.glob("_pytest/data/websocket/1485975606.59-team_join.json")
 
-    print datafiles
+    print(datafiles)
     #assert False
 
     notimplemented = set()
 
     for fname in datafiles:
         try:
-            print "####################"
+            print("####################")
             data = json.loads(open(fname, 'r').read())
             socket.add(data)
-            print data
+            print(data)
             eventrouter.receive_ws_callback(t)
             eventrouter.handle_next()
         except ProcessNotImplemented as e:
@@ -43,11 +45,11 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
             pass
 
     if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
+        print("####################")
+        print(sorted(notimplemented))
+        print("####################")
 
-    #print len(eventrouter.queue)
+    #print(len(eventrouter.queue))
     assert len(eventrouter.teams[t].users) == 4
 
 

--- a/_pytest/test_sendmessage.py
+++ b/_pytest/test_sendmessage.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 def test_send_message(realish_eventrouter, mock_websocket):
     e = realish_eventrouter
@@ -6,7 +7,7 @@ def test_send_message(realish_eventrouter, mock_websocket):
     #u = e.teams[t].users.keys()[0]
 
     #user = e.teams[t].users[u]
-    #print user
+    #print(user)
 
     socket = mock_websocket
     e.teams[t].ws = socket
@@ -16,6 +17,6 @@ def test_send_message(realish_eventrouter, mock_websocket):
     channel = e.teams[t].channels[c]
     channel.send_message('asdf')
 
-    print c
+    print(c)
 
     #assert False

--- a/_pytest/test_slackchannel.py
+++ b/_pytest/test_slackchannel.py
@@ -1,33 +1,35 @@
+from __future__ import print_function
+
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['C3ZEQAYN7']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 
-    print "-------"
-    print c == "random"
-    print "-------"
-    print c == "#random"
-    print "-------"
-    print c == "weeslacktest.slack.com.#random"
-    print "-------"
-    print c == "weeslacktest.slack.com.random"
-    print "-------"
-    print c == "dandom"
+    print("-------")
+    print(c == "random")
+    print("-------")
+    print(c == "#random")
+    print("-------")
+    print(c == "weeslacktest.slack.com.#random")
+    print("-------")
+    print(c == "weeslacktest.slack.com.random")
+    print("-------")
+    print(c == "dandom")
 
-    print e.weechat_controller.buffers
+    print(e.weechat_controller.buffers)
     #assert False

--- a/_pytest/test_slackdmchannel.py
+++ b/_pytest/test_slackdmchannel.py
@@ -1,20 +1,22 @@
+from __future__ import print_function
+
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackDMChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['D3ZEQULHZ']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackgroupchannel.py
+++ b/_pytest/test_slackgroupchannel.py
@@ -1,20 +1,22 @@
+from __future__ import print_function
+
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackGroupChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['G3ZJKP7GA']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackmpdmchannel.py
+++ b/_pytest/test_slackmpdmchannel.py
@@ -1,20 +1,22 @@
+from __future__ import print_function
+
 from mock import Mock
 #from wee_slack import SlackChannel
 
 def test_SlackMPDMChannel(realish_eventrouter):
     e = realish_eventrouter
 
-    print e.sc["team"].channels
+    print(e.sc["team"].channels)
     #c = SlackChannel(e, **json.loads(chan))
     c = e.sc["team"].channels['G3ZGMF4RZ']
 
-    print c.formatted_name()
+    print(c.formatted_name())
     c.is_someone_typing = Mock(return_value=True)
     c.channel_buffer = Mock(return_value=True)
-    print c.create_buffer()
-    print c.rename()
-    print c.current_short_name
-    print c.formatted_name()
-    print c.rename()
-    print c.formatted_name()
+    print(c.create_buffer())
+    print(c.rename())
+    print(c.current_short_name)
+    print(c.formatted_name())
+    print(c.rename())
+    print(c.formatted_name())
 #    assert False

--- a/_pytest/test_slackrequest.py
+++ b/_pytest/test_slackrequest.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+
 from wee_slack import SlackRequest, EventRouter
 
 def test_SlackRequest():
     s = SlackRequest('xoxoxoxox', "blah.get", {"meh": "blah"})
-    print s
+    print(s)
 
     e = EventRouter()
     e.receive(s)

--- a/_pytest/test_slackteam.py
+++ b/_pytest/test_slackteam.py
@@ -4,7 +4,7 @@ def test_SlackTeam():
     e = EventRouter()
     #s = SlackTeam('xoxo')
     #e.register_team(s)
-    #print e.queue
-    #print e.handle_next()
+    #print(e.queue)
+    #print(e.handle_next())
     #assert False
 

--- a/foobar.py
+++ b/foobar.py
@@ -1,0 +1,9 @@
+import sys
+sys.path.append('./_pytest')
+from conftest import FakeWeechat
+import wee_slack
+wee_slack.w = FakeWeechat()
+from wee_slack import PluginConfig
+pc = PluginConfig()
+pc.get_debug_level('debug_level')
+pc.debug_level

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3775,17 +3775,20 @@ class PluginConfig(object):
         return w.WEECHAT_RC_OK
 
     def fetch_setting(self, key):
-        if hasattr(self, 'get_' + key):
-            try:
-                return getattr(self, 'get_' + key)(key)
-            except:
-                return self.settings[key]
-        else:
+        try:
+            return getattr(self, 'get_' + key)(key)
+        except AttributeError:
             # Most settings are on/off, so make get_boolean the default
             return self.get_boolean(key)
+        except:
+            # There was setting-specific getter, but it failed.
+            return self.settings[key]
 
     def __getattr__(self, key):
-        return self.settings[key]
+        try:
+            return self.settings[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def get_boolean(self, key):
         return w.config_string_to_boolean(w.config_get_plugin(key))

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2129,6 +2129,21 @@ class SlackTS(object):
             elif s == other:
                 return 0
 
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+
     def __hash__(self):
         return hash("{}.{}".format(self.major, self.minor))
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -20,10 +20,14 @@ import collections
 import ssl
 import random
 import string
+
 try:
-    from cStringIO import StringIO
-except:
-    from StringIO import StringIO
+    from io import StringIO
+except ImportError:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
 
 from websocket import create_connection, WebSocketConnectionClosedException
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 
 from collections import OrderedDict
 from functools import wraps
@@ -1149,7 +1149,7 @@ class SlackTeam(object):
             self.ws.send(encode_to_utf8(message))
             dbg("Sent {}...".format(message[:100]))
         except:
-            print "WS ERROR"
+            print("WS ERROR")
             dbg("Unexpected error: {}\nSent: {}".format(sys.exc_info()[0], data))
             self.set_connected()
 
@@ -3848,9 +3848,9 @@ def trace_calls(frame, event, arg):
     caller = frame.f_back
     caller_line_no = caller.f_lineno
     caller_filename = caller.f_code.co_filename
-    print >> f, 'Call to %s on line %s of %s from line %s of %s' % \
+    print('Call to %s on line %s of %s from line %s of %s' % \
         (func_name, func_line_no, func_filename,
-         caller_line_no, caller_filename)
+         caller_line_no, caller_filename), file=f)
     f.flush()
     return
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -13,7 +13,6 @@ import pickle
 import sha
 import os
 import re
-import urllib
 import sys
 import traceback
 import collections
@@ -28,6 +27,13 @@ except ImportError:
         from cStringIO import StringIO
     except ImportError:
         from StringIO import StringIO
+
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlencode
+    from urllib2 import urlopen
 
 from websocket import create_connection, WebSocketConnectionClosedException
 
@@ -937,7 +943,7 @@ class SlackRequest(object):
         post_data["token"] = token
         self.post_data = post_data
         self.params = {'useragent': 'wee_slack {}'.format(SCRIPT_VERSION)}
-        self.url = 'https://{}/api/{}?{}'.format(self.domain, request, urllib.urlencode(encode_to_utf8(post_data)))
+        self.url = 'https://{}/api/{}?{}'.format(self.domain, request, urlencode(encode_to_utf8(post_data)))
         self.response_id = sha.sha("{}{}".format(self.url, self.start_time)).hexdigest()
         self.retries = kwargs.get('retries', 3)
 #    def __repr__(self):
@@ -3130,7 +3136,7 @@ def command_register(data, current_buffer, args):
         "https://slack.com/api/oauth.access?"
         "client_id={}&client_secret={}&code={}"
     ).format(CLIENT_ID, CLIENT_SECRET, oauth_code)
-    ret = urllib.urlopen(uri).read()
+    ret = urlopen(uri).read()
     d = json.loads(ret)
     if not d["ok"]:
         w.prnt("",

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -10,7 +10,7 @@ import textwrap
 import time
 import json
 import pickle
-import sha
+import hashlib
 import os
 import re
 import sys
@@ -206,6 +206,8 @@ def get_nick_color_name(nick):
     info_name_prefix = "irc_" if int(weechat_version) < 0x1050000 else ""
     return w.info_get(info_name_prefix + "nick_color_name", nick)
 
+def sha1_hex(s):
+    return hashlib.sha1(s.encode()).hexdigest()
 
 ##### BEGIN NEW
 
@@ -944,7 +946,7 @@ class SlackRequest(object):
         self.post_data = post_data
         self.params = {'useragent': 'wee_slack {}'.format(SCRIPT_VERSION)}
         self.url = 'https://{}/api/{}?{}'.format(self.domain, request, urlencode(encode_to_utf8(post_data)))
-        self.response_id = sha.sha("{}{}".format(self.url, self.start_time)).hexdigest()
+        self.response_id = sha1_hex("{}{}".format(self.url, self.start_time))
         self.retries = kwargs.get('retries', 3)
 #    def __repr__(self):
 #        return "URL: {} Tries: {} ID: {}".format(self.url, self.tries, self.response_id)
@@ -954,7 +956,7 @@ class SlackRequest(object):
 
     def tried(self):
         self.tries += 1
-        self.response_id = sha.sha("{}{}".format(self.url, time.time())).hexdigest()
+        self.response_id = sha1_hex("{}{}".format(self.url, time.time()))
 
     def should_try(self):
         return self.tries < self.retries
@@ -1087,7 +1089,7 @@ class SlackTeam(object):
 
     @staticmethod
     def generate_team_hash(nick, subdomain):
-        return str(sha.sha("{}{}".format(nick, subdomain)).hexdigest())
+        return str(sha1_hex("{}{}".format(nick, subdomain)))
 
     def refresh(self):
         self.rename()
@@ -1612,7 +1614,7 @@ class SlackChannel(object):
         ts = SlackTS(ts)
 
         def calc_hash(msg):
-            return sha.sha(str(msg.ts)).hexdigest()
+            return sha1_hex(str(msg.ts))
 
         if ts in self.messages and not self.messages[ts].hash:
             message = self.messages[ts]


### PR DESCRIPTION
A while back I forward-ported #331 (see my comment there). I see #555 was submitted, but seems to have stalled. Here's the first part of my attempt at compatibility with Python 3 (without breaking Python 2).

I have [a branch](https://github.com/smaeul/wee-slack/tree/python3-2) that passes all tests on Python 3, as well as loads, registers, and connects to Slack. Unfortunately, it seems to get stuck after that. I'm not sure that some of the later changes there are correct, because of the magic utf8 wrappers. This is the subset of changes that shouldn't break anything, at least.