### PR TITLE
fix: corrected registration instructions

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3142,7 +3142,7 @@ def command_register(data, current_buffer, args):
                             ','.join([tok, d['access_token']]))
 
     w.prnt("", "Success! Added team \"%s\"" % (d['team_name'],))
-    w.prnt("", "Please reload wee-slack with: /script reload slack")
+    w.prnt("", "Please reload wee-slack with: /python reload slack")
 
 
 @slack_buffer_or_ignore


### PR DESCRIPTION
in the registration dialog, wee_slack asks the user to reload the
slack script via /script. in my weechat 2.1 on debian sid, this is
not the proper way to reload scripts anymore. instead one has to
use the /python command to achieve the same effect. this commit
corrects the misleading instruction message.