### PR TITLE
docs: added hint to python plugin packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Dependencies
 ------------
   * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
+  * Some distributions package weechats plugin functionalities in separate packages
+    make sure your weechat supports python plugins. Under Debian, install ```weechat-python```
 
 Setup
 ------


### PR DESCRIPTION
the installations instructions did not provide any hints, that
not every weechat distribution comes with batteries included.
to save the users time, i added a hint to README.md