### PR TITLE
readme: add hint about split-packaging in distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Dependencies
 ------------
   * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
+  * Some distributions package weechat's plugin functionalities in separate packages.
+    Be sure that your weechat supports python plugins. Under Debian, install `weechat-python`
 
 Setup
 ------


### PR DESCRIPTION
some distributions do not distribute weechat with support for all
plugins by default, but use separate packages to provide support
for different scripting languages. users should be made aware of that