### PR TITLE
add http proxy support

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -225,7 +225,7 @@ class ProxyWrapper(object):
             if self.proxy_port:
                 port = ":{}".format(self.proxy_port)
             else:
-                port= ""
+                port = ""
                 
             return "--proxy {}{}{}".format(user, self.proxy_address, port)
 
@@ -1143,7 +1143,8 @@ class SlackTeam(object):
             self.connecting = True
             if self.ws_url:
                 try:
-                    # only http proxy is currenlty supported
+                    # only http proxy is currently supported
+                    proxy = ProxyWrapper()
                     if proxy.has_proxy == True:
                         ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs, http_proxy_host=proxy.proxy_address, http_proxy_port=proxy.proxy_port, http_proxy_auth=(proxy.proxy_user, proxy.proxy_password))
                     else:
@@ -3475,8 +3476,9 @@ def command_upload(data, current_buffer, args):
         file_path = file_path.replace(' ', '\ ')
 
     # only http proxy is currenlty supported
+    proxy = ProxyWrapper()
     proxy_string = proxy.curl()
-    command = 'curl -F file=@{} -F channels={} -F token={} {} {}'.format(file_path, channel.identifier, team.token, proxy, url)
+    command = 'curl -F file=@{} -F channels={} -F token={} {} {}'.format(file_path, channel.identifier, team.token, proxy_string, url)
     w.hook_process(command, config.slack_timeout, '', '')
 
 @utf8_decode
@@ -3938,9 +3940,6 @@ if __name__ == "__main__":
 
     if w.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE,
                   SCRIPT_DESC, "script_unloaded", ""):
-
-        global proxy
-        proxy = ProxyWrapper()
 
         weechat_version = w.info_get("version_number", "") or 0
         if int(weechat_version) < 0x1030000:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3164,12 +3164,12 @@ def command_register_callback(data, command, return_code, out, err):
                 w.config_set_plugin('slack_api_token',
                                     ','.join([tok, d['access_token']]))
 
-                w.prnt("", "Success! Added team \"%s\"" % (d['team_name'],))
-                w.prnt("", "Please reload wee-slack with: /script reload slack")
-                return w.WEECHAT_RC_OK_EAT
-           w.prnt("", "ERROR: problem when trying to get Slack OAuth token. Got 0 length answer. Err: ".format(err))
-           w.prnt("", "Check the network or proxy settings")
-           return w.WEECHAT_RC_OK_EAT
+            w.prnt("", "Success! Added team \"%s\"" % (d['team_name'],))
+            w.prnt("", "Please reload wee-slack with: /script reload slack")
+            return w.WEECHAT_RC_OK_EAT
+        w.prnt("", "ERROR: problem when trying to get Slack OAuth token. Got 0 length answer. Err: ".format(err))
+        w.prnt("", "Check the network or proxy settings")
+        return w.WEECHAT_RC_OK_EAT
     w.prnt("", "ERROR: problem when trying to get Slack OAuth token. Got return code {}. Err: ".format(return_code, err))
     w.prnt("", "Check the network or proxy settings")
     return w.WEECHAT_RC_OK_EAT

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -211,23 +211,23 @@ class ProxyWrapper(object):
                 self.proxy_password = w.config_string(weechat.config_get("{}.password".format(self.proxy_string)))
                 self.has_proxy = True
             else:
-                w.prnt("", "\nWarning: weechat.network.proxy_curl is set to {} (name : {}, conf string : {})type. Only HTTP proxy is supported.\n\n".format(self.proxy_type, self.proxy_name, self.proxy_string))
+                w.prnt("", "\nWarning: weechat.network.proxy_curl is set to {} type (name : {}, conf string : {}). Only HTTP proxy is supported.\n\n".format(self.proxy_type, self.proxy_name, self.proxy_string))
         
-        def curl(self):
-            if not self.has_proxy:
-                return ""
-            
-            if self.proxy_user and self.proxy_password:
-                user = "{}:{}@".format(self.proxy_user, self.proxy_password)
-            else:
-                user = ""
+    def curl(self):
+        if not self.has_proxy:
+            return ""
+        
+        if self.proxy_user and self.proxy_password:
+            user = "{}:{}@".format(self.proxy_user, self.proxy_password)
+        else:
+            user = ""
                     
-            if self.proxy_port:
-                port = ":{}".format(self.proxy_port)
-            else:
-                port = ""
+        if self.proxy_port:
+            port = ":{}".format(self.proxy_port)
+        else:
+            port = ""
                 
-            return "--proxy {}{}{}".format(user, self.proxy_address, port)
+        return "--proxy {}{}{}".format(user, self.proxy_address, port)
 
 
 ##### Helpers

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1104,8 +1104,8 @@ class SlackTeam(object):
             if self.ws_url:
                 try:
                     # only http proxy is currenlty supported
-                    proxy_name = proxy = weechat.config_string(weechat.config_get('weechat.network.proxy_curl'))
-                    if not proxy_name:
+                    proxy_name = weechat.config_string(weechat.config_get('weechat.network.proxy_curl'))
+                    if proxy_name:
                         proxy_string = "weechat.proxy.{}".format(proxy_name)
                         proxy_type = weechat.config_string(weechat.config_get("{}.type".format(proxy_string)))
                         if proxy_type == "http":
@@ -1114,11 +1114,10 @@ class SlackTeam(object):
                             proxy_user = weechat.config_string(weechat.config_get("{}.username".format(proxy_string)))
                             proxy_password = weechat.config_string(weechat.config_get("{}.password".format(proxy_string)))
 
-                            if not proxy_address:
-                                ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs)
-                            else:
-                                ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs, http_proxy_host=proxy_address, http_proxy_port=proxy_port, http_proxy_auth=(proxy_user, proxy_password))
-
+                    if not proxy_name:
+                        ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs)
+                    else:
+                        ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs, http_proxy_host=proxy_address, http_proxy_port=proxy_port, http_proxy_auth=(proxy_user, proxy_password))
                     self.hook = w.hook_fd(ws.sock._sock.fileno(), 1, 0, 0, "receive_ws_callback", self.get_team_hash())
                     ws.sock.setblocking(0)
                     self.ws = ws

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1104,15 +1104,15 @@ class SlackTeam(object):
             if self.ws_url:
                 try:
                     # only http proxy is currenlty supported
-                    proxy_name = weechat.config_string(weechat.config_get('weechat.network.proxy_curl'))
+                    proxy_name = w.config_string(weechat.config_get('weechat.network.proxy_curl'))
                     if proxy_name:
                         proxy_string = "weechat.proxy.{}".format(proxy_name)
-                        proxy_type = weechat.config_string(weechat.config_get("{}.type".format(proxy_string)))
+                        proxy_type = w.config_string(weechat.config_get("{}.type".format(proxy_string)))
                         if proxy_type == "http":
-                            proxy_address = weechat.config_string(weechat.config_get("{}.address".format(proxy_string)))
-                            proxy_port = weechat.config_integer(weechat.config_get("{}.port".format(proxy_string)))
-                            proxy_user = weechat.config_string(weechat.config_get("{}.username".format(proxy_string)))
-                            proxy_password = weechat.config_string(weechat.config_get("{}.password".format(proxy_string)))
+                            proxy_address = w.config_string(weechat.config_get("{}.address".format(proxy_string)))
+                            proxy_port = w.config_integer(weechat.config_get("{}.port".format(proxy_string)))
+                            proxy_user = w.config_string(weechat.config_get("{}.username".format(proxy_string)))
+                            proxy_password = w.config_string(weechat.config_get("{}.password".format(proxy_string)))
 
                     if not proxy_name:
                         ws = create_connection(self.ws_url, sslopt=sslopt_ca_certs)
@@ -3434,15 +3434,15 @@ def command_upload(data, current_buffer, args):
 
     # only http proxy is currenlty supported
     proxy = ""
-    proxy_name = proxy = weechat.config_string(weechat.config_get('weechat.network.proxy_curl'))
+    proxy_name = proxy = w.config_string(weechat.config_get('weechat.network.proxy_curl'))
     if not proxy_name:
         proxy_string = "weechat.proxy.{}".format(proxy_name)
-        proxy_type = weechat.config_integer(weechat.config_get("{}.type".format(proxy_string)))
+        proxy_type = w.config_integer(weechat.config_get("{}.type".format(proxy_string)))
         if proxy_type == "http":
-            proxy_address = weechat.config_string(weechat.config_get("{}.address".format(proxy_string)))
-            proxy_port = weechat.config_string(weechat.config_get("{}.port".format(proxy_string)))
-            proxy_user = weechat.config_string(weechat.config_get("{}.username".format(proxy_string)))
-            proxy_password = weechat.config_string(weechat.config_get("{}.password".format(proxy_string)))
+            proxy_address = w.config_string(weechat.config_get("{}.address".format(proxy_string)))
+            proxy_port = w.config_string(weechat.config_get("{}.port".format(proxy_string)))
+            proxy_user = w.config_string(weechat.config_get("{}.username".format(proxy_string)))
+            proxy_password = w.config_string(weechat.config_get("{}.password".format(proxy_string)))
             proxy = "--proxy "
 
             if proxy_user and proxy_password:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3211,7 +3211,7 @@ def command_register_callback(data, command, return_code, out, err):
                             ','.join([tok, d['access_token']]))
 
     w.prnt("", "Success! Added team \"%s\"" % (d['team_name'],))
-    w.prnt("", "Please reload wee-slack with: /script reload slack")
+    w.prnt("", "Please reload wee-slack with: /python reload slack")
     return w.WEECHAT_RC_OK_EAT
 
 


### PR DESCRIPTION
See issue #573
The proxy can be configured within weechat using /proxy command and weechat.network.proxy_curl settings.
Upload has not be tested because I didn't have anythin to upload. But it should work