### PR TITLE
Don't raise exception on missing event callbacks

### DIFF
--- a/_pytest/test_eventrouter.py
+++ b/_pytest/test_eventrouter.py
@@ -1,5 +1,5 @@
 import pytest
-from wee_slack import EventRouter, ProcessNotImplemented, SlackRequest
+from wee_slack import EventRouter, SlackRequest
 
 def test_EventRouter(mock_weechat):
     # Sending valid json adds to the queue.
@@ -24,12 +24,11 @@ def test_EventRouter(mock_weechat):
     assert len(e.queue) == 0
 
     # Handling an event without an associated processor
-    # raises an exception.
+    # shouldn't raise an exception.
     e = EventRouter()
     # Create a function to test we are called
     e.receive_json('{"type": "testfunc"}')
-    with pytest.raises(ProcessNotImplemented):
-        e.handle_next()
+    e.handle_next()
 
 def test_EventRouterReceivedata(mock_weechat):
 

--- a/_pytest/test_everything.py
+++ b/_pytest/test_everything.py
@@ -1,50 +1,21 @@
 import glob
 import json
 
-#from wee_slack import render
-from wee_slack import ProcessNotImplemented
-
 def test_everything(realish_eventrouter, mock_websocket):
 
     eventrouter = realish_eventrouter
 
     t = eventrouter.teams.keys()[0]
-    #u = eventrouter.teams[t].users.keys()[0]
-
-    #user = eventrouter.teams[t].users[u]
-    #print user
 
     socket = mock_websocket
     eventrouter.teams[t].ws = socket
 
     datafiles = glob.glob("_pytest/data/websocket/*.json")
 
-    print datafiles
-    #assert False
-
-    notimplemented = set()
-
     for fname in datafiles:
-        try:
-            print "####################"
-            data = json.loads(open(fname, 'r').read())
-            socket.add(data)
-            print data
-            eventrouter.receive_ws_callback(t)
-            eventrouter.handle_next()
-        except ProcessNotImplemented as e:
-            notimplemented.add(str(e))
-        #this handles some message data not existing - need to fix
-        except KeyError:
-            pass
+        data = json.loads(open(fname, 'r').read())
+        socket.add(data)
+        eventrouter.receive_ws_callback(t)
+        eventrouter.handle_next()
 
-    if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
-
-    print len(eventrouter.queue)
-    #assert False
-
-
-
+    assert len(eventrouter.queue) == 14

--- a/_pytest/test_processteamjoin.py
+++ b/_pytest/test_processteamjoin.py
@@ -1,17 +1,11 @@
 import glob
 import json
 
-from wee_slack import ProcessNotImplemented
-
 def test_process_team_join(mock_websocket, realish_eventrouter):
 
     eventrouter = realish_eventrouter
 
     t = eventrouter.teams.keys()[0]
-    #u = eventrouter.teams[t].users.keys()[0]
-
-    #user = eventrouter.teams[t].users[u]
-    #print user
 
     #delete charles so we can add him
     del eventrouter.teams[t].users['U4096CBHC']
@@ -23,32 +17,10 @@ def test_process_team_join(mock_websocket, realish_eventrouter):
 
     datafiles = glob.glob("_pytest/data/websocket/1485975606.59-team_join.json")
 
-    print datafiles
-    #assert False
-
-    notimplemented = set()
-
     for fname in datafiles:
-        try:
-            print "####################"
-            data = json.loads(open(fname, 'r').read())
-            socket.add(data)
-            print data
-            eventrouter.receive_ws_callback(t)
-            eventrouter.handle_next()
-        except ProcessNotImplemented as e:
-            notimplemented.add(str(e))
-        #this handles some message data not existing - need to fix
-        except KeyError:
-            pass
+        data = json.loads(open(fname, 'r').read())
+        socket.add(data)
+        eventrouter.receive_ws_callback(t)
+        eventrouter.handle_next()
 
-    if len(notimplemented) > 0:
-        print "####################"
-        print sorted(notimplemented)
-        print "####################"
-
-    #print len(eventrouter.queue)
     assert len(eventrouter.teams[t].users) == 4
-
-
-

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -496,7 +496,7 @@ class EventRouter(object):
                     elif function_name in self.handlers:
                         self.handlers[function_name](j, self, **kwargs)
                     else:
-                        raise ProcessNotImplemented(function_name)
+                        dbg("Callback not implemented for event: {}".format(function_name))
 
 
 def handle_next(*args):
@@ -3501,15 +3501,6 @@ def command_p(data, current_buffer, args):
     w.prnt("", "{}".format(eval(args)))
 
 ###### NEW EXCEPTIONS
-
-
-class ProcessNotImplemented(Exception):
-    """
-    Raised when we try to call process_(something), but
-    (something) has not been defined as a function.
-    """
-    def __init__(self, function_name):
-        super(ProcessNotImplemented, self).__init__(function_name)
 
 
 class InvalidType(Exception):


### PR DESCRIPTION
These missing callbacks are not really errors or exceptions, and we
don't need to implement all of them. Raising an exception makes the
users think something isn't working, and is confusing.