### PR TITLE
Adding support for new slack upload message style

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2114,11 +2114,12 @@ class SlackMessage(object):
             )
 
         if message_json.get('upload'):
+            parts = [message_json['text']]
             for f in message_json.get('files', []):
-                message_json['text'] = "{} | ({}) - {}".format(
-                    message_json['text'],
+                parts.append("({}) - {}".format(
                     f.get('title'),
-                    f.get('url_private'))
+                    f.get('url_private')))
+            message_json['text'] = ' | '.join(p for p in parts if p)
 
     def __hash__(self):
         return hash(self.ts)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2113,6 +2113,13 @@ class SlackMessage(object):
                 message_json['text']
             )
 
+        if message_json.get('upload'):
+            for f in message_json.get('files', []):
+                message_json['text'] = "{} | ({}) - {}".format(
+                    message_json['text'],
+                    f.get('title'),
+                    f.get('url_private'))
+
     def __hash__(self):
         return hash(self.ts)
 


### PR DESCRIPTION
Looks like slack recently changed the format for upload messages, this is a relatively quick and dirty fix to include the uploaded file title and url in the messages. 