### PR TITLE
Reply to existing thread with a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Open an existing thread as a channel. The argument is the thread identifier, whi
 /thread af8
 ```
 
+Reply to an existing thread. The second argument is the thread identifier, which is printed in square brackets with every threaded message in a channel:
+```
+/thread af8 Hello thread!
+```
+
 Label a thread with a memorable name. The above command will open a channel called af8, but perhaps you want to call it "meetingnotes". To do so, select that buffer and type:
 ```
 /label meetingnotes

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3460,6 +3460,13 @@ def thread_command_callback(data, current_buffer, args):
                     pm = channel.hashed_messages[args[1]]
                 pm.open_thread(switch=config.switch_buffer_on_join)
                 return w.WEECHAT_RC_OK_EAT
+            elif len(args) >= 3:
+                try:
+                    pm = channel.messages[SlackTS(args[1])]
+                except:
+                    pm = channel.hashed_messages[args[1]]
+                channel.send_message(' '.join(args[2:]), request_dict_ext={"thread_ts": str(pm.ts)})
+                return w.WEECHAT_RC_OK_EAT
         elif args[0] == '/reply':
             count = int(args[1])
             msg = " ".join(args[2:])


### PR DESCRIPTION
This allows for replying in threads existing threads using command:

```
/thread b4d Hello thread!
```

Useful with the feature to show thread messages in the parent channel, see #616 