### PR TITLE
Add support for `/slack upload`-ing remote URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Upload a file to the current slack buffer:
 ```
 /slack upload [file_path]
 ```
+`file_path` can be a URL, in which case wee-slack will automatically download it and attach it as if it had been a local file.
 
 Run a Slack slash command. Simply prepend `/slack slash` to what you'd type in the official clients.:
 ```

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -12,8 +12,10 @@ import json
 import pickle
 import sha
 import os
+import os.path
 import re
 import urllib
+import urlparse
 import sys
 import traceback
 import collections
@@ -3607,10 +3609,13 @@ def command_upload(data, current_buffer, args):
     fname = args.split(' ', 1)
     file_path = os.path.expanduser(fname[1])
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
+    if re.match("https?:\/\/", file_path):
+        remote_fn = os.path.basename(urlparse.urlparse(file_path).path)
+        file_path, _ = urllib.urlretrieve(file_path, "/tmp/{}".format(remote_fn))
     if ' ' in file_path:
         file_path = file_path.replace(' ', '\ ')
 
-    # only http proxy is currenlty supported
+    # only http proxy is currently supported
     proxy = ProxyWrapper()
     proxy_string = proxy.curl()
     command = 'curl -F file=@{} -F channels={} -F token={} {} {}'.format(file_path, channel.identifier, team.token, proxy_string, url)


### PR DESCRIPTION
At the moment, `/slack upload` only supports local filenames, which is a bit limiting, especailly for those of us who use weechat over SSH. This simple patch adds support for something like:

`/slack upload https://github.com/Microsoft/MS-DOS/raw/master/msdos-logo.png`

which results in:

![](http://screenshot.apetre.sc/2018-09-30-20.26.55.png)

The only weakness I can see with this implementation is that it does the _download_ on the main thread (it still uses `hook_process()` for the upload). I don't anticipate this to be an issue since the types of remote files people generally upload are images or code files which will download very quickly, but let me know if this is a blocker and I need to spawn a background process for that too.
