### PR TITLE
Add linkarchive slack command to create a link to a given message

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ Run a Slack slash command. Simply prepend `/slack slash` to what you'd type in t
 /slack slash /desiredcommand arg1 arg2 arg3
 ```
 
+Paste in the input the slack link to some message:
+```
+/slack linkarchive [$]message_id
+```
+This command is intended to be used with the mouse or cursor mode (see
+below section).
+
 To send a command as a normal message instead of performing the action, prefix it with a slash or a space, like so:
 ```
 //slack
@@ -270,18 +277,21 @@ To enable tab completion of emojis, copy or symlink the `weemoji.json` file to y
 #### Cursor and mouse mode
 
 The cursor mode and mouse mode can be used to interact with older messages, for editing, deleting, reacting and replying to a message. The default behavior when right-clicking on a message is to paste its id in the input. It can be used in `/reply`, `s/` substitution/deletion and in `+:emoji:` commands instead of a message number.
+It can also be used as an argument to the `/slack linkarchive` command.
 
 In cursor mode, the `M` key achieves the same result (memo: the default for weechat is to paste the message with `m`, `M` simply copies the id).
 In addition, `R` will prepare a `/reply id` and `D` will delete the message (provided it’s yours).
 `T` will open the thread associated to a message, equivalent to `/thread id`
+`L` will call the `/slack linkarchive` command behind the hood and paste it to the current input.
 
 Please see weechat’s documentation about [how to use the cursor mode](https://weechat.org/files/doc/stable/weechat_user.en.html#key_bindings_cursor_context) or [adapt the bindings](https://weechat.org/files/doc/stable/weechat_user.en.html#command_weechat_key) to your preference.
 
 Default:
 ```
 /key bindctxt mouse @chat(python.*.slack.com.*):button2 hsignal:slack_mouse
-/key bindctxt cursor @chat(python.*.slack.com.*):M hsignal:slack_cursor_message
 /key bindctxt cursor @chat(python.*.slack.com.*):D hsignal:slack_cursor_delete
+/key bindctxt cursor @chat(python.*.slack.com.*):L hsignal:slack_cursor_linkarchive
+/key bindctxt cursor @chat(python.*.slack.com.*):M hsignal:slack_cursor_message
 /key bindctxt cursor @chat(python.*.slack.com.*):R hsignal:slack_cursor_reply
 /key bindctxt cursor @chat(python.*.slack.com.*):T hsignal:slack_cursor_thread
 ```


### PR DESCRIPTION
This PR makes a small addition thanks to the new "line message search" feature: it permits to paste in the input the full link to a given message, obtained either by its thread id or by clicking / cursoring it.