### PR TITLE
Include threads when marking latest message as read

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1702,7 +1702,7 @@ class SlackChannel(SlackChannelCommon):
                 w.buffer_set(self.channel_buffer, "unread", "")
                 w.buffer_set(self.channel_buffer, "hotlist", "-1")
             if not ts:
-                ts = next(self.main_message_keys_reversed(), SlackTS())
+                ts = next(reversed(self.messages), SlackTS())
             if ts > self.last_read:
                 self.last_read = ts
             if update_remote:


### PR DESCRIPTION
This is the same as #549, which I closed originally to work on a more complicated solution that tackled some other thread-related things. With #616 I feel that solution isn't necessary anymore though, and this simple change actually pairs nicely with enabling `thread_messages_in_channel` (but it'll still fix channels not being marked as read regardless).