### PR TITLE
Load `weemoji.json` with UTF-8

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3826,7 +3826,7 @@ def create_slack_debug_buffer():
 def load_emoji():
     try:
         DIR = w.info_get("weechat_dir", "")
-        with open('{}/weemoji.json'.format(DIR), 'r') as ef:
+        with open('{}/weemoji.json'.format(DIR), 'r', encoding='utf8') as ef:
             return json.loads(ef.read())["emoji"]
     except Exception as e:
         dbg("Couldn't load emoji list: {}".format(e), 5)


### PR DESCRIPTION
I had to do this to make `wee-slack` work on my machine. Not sure why it was needed.