### PR TITLE
Fix bug preventing first line in buffer to be changed

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -94,6 +94,7 @@ class FakeWeechat():
 def mock_weechat():
     wee_slack.w = FakeWeechat()
     wee_slack.config = wee_slack.PluginConfig()
+    wee_slack.hdata = wee_slack.Hdata(wee_slack.w)
     wee_slack.debug_string = None
     wee_slack.slack_debug = "debug_buffer_ptr"
     wee_slack.STOP_TALKING_TO_SLACK = False


### PR DESCRIPTION
This rewrites modify_buffer_line and modify_print_time (now modify_last_print_time to be more clear) to be much more readable.
    
modify_buffer_line had a bug where it moved past the first line, causing the line_pointer to be lost so the first line couldn't be updated. This is now fixed.