### PR TITLE
Two fixes of topic handling

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1461,6 +1461,7 @@ class SlackChannel(SlackChannelCommon):
             topic = self.topic['value']
             if topic == "":
                 topic = self.slack_purpose['value']
+            topic = unhtmlescape(unfurl_refs(topic, ignore_alt_text=False))
             w.buffer_set(self.channel_buffer, "title", topic)
 
     def set_topic(self, value):
@@ -2727,7 +2728,7 @@ def subprocess_message_deleted(message_json, eventrouter, channel, team):
 def subprocess_channel_topic(message_json, eventrouter, channel, team):
     text = unhtmlescape(unfurl_refs(message_json["text"], ignore_alt_text=False))
     channel.buffer_prnt(w.prefix("network").rstrip(), text, message_json["ts"], tagset="topic")
-    channel.set_topic(unhtmlescape(message_json["topic"]))
+    channel.set_topic(message_json["topic"])
 
 
 def process_reply(message_json, eventrouter, **kwargs):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1373,7 +1373,7 @@ class SlackChannel(SlackChannelCommon):
         self.eventrouter = eventrouter
         self.slack_name = kwargs["name"]
         self.slack_purpose = kwargs.get("purpose", {"value": ""})
-        self.topic = kwargs.get("topic", {}).get("value", "")
+        self.topic = kwargs.get("topic", {"value": ""})
         self.identifier = kwargs["id"]
         self.last_read = SlackTS(kwargs.get("last_read", SlackTS()))
         self.channel_buffer = None
@@ -1458,14 +1458,13 @@ class SlackChannel(SlackChannelCommon):
 
     def render_topic(self):
         if self.channel_buffer:
-            if self.topic != "":
-                topic = self.topic
-            else:
+            topic = self.topic['value']
+            if topic == "":
                 topic = self.slack_purpose['value']
             w.buffer_set(self.channel_buffer, "title", topic)
 
     def set_topic(self, value):
-        self.topic = value
+        self.topic = {"value": value}
         self.render_topic()
 
     def update_from_message_json(self, message_json):
@@ -1806,7 +1805,7 @@ class SlackDMChannel(SlackChannel):
         self.update_color()
         self.set_name(self.slack_name)
         if dmuser in users:
-            self.topic = create_user_status_string(users[dmuser].profile)
+            self.set_topic(create_user_status_string(users[dmuser].profile))
 
     def set_related_server(self, team):
         super(SlackDMChannel, self).set_related_server(team)


### PR DESCRIPTION
Fixes:

* `wrong arguments for function "buffer_set"` when joining a channel
  from the web client

* resolve references (e.g. `<@JHDJFHKDW>`) in topic

I'm still not really happy with the code, seems to me that
using `update_from_message_json` to fill channel attributes is really
dangerous and we should avoid it. I'm not sure what will break if I just
drop the call. Does anyone here know or shall I just drop it and try
running that for a while?