### PR TITLE
Fix /slack linkarchive command because of an API change

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3705,7 +3705,7 @@ def command_linkarchive(data, current_buffer, args):
                 message_id = args
             message = channel.hashed_messages.get(message_id)
             if message:
-                url += '{}{:0>6}'.format(message.ts.majorstr(), message.ts.minorstr())
+                url += 'p{}{:0>6}'.format(message.ts.majorstr(), message.ts.minorstr())
                 if isinstance(message, SlackThreadMessage):
                     url += "?thread_ts={}&cid={}".format(message.parent_message.ts, channel.identifier)
             else:


### PR DESCRIPTION
* for details please see: https://api.slack.com/methods/chat.getPermalink