### PR TITLE
Add ability to open last thread in channel without specifying message id

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Open an existing thread as a channel. The argument is the thread identifier, whi
 /thread af8
 ```
 
+To access the last thread in a channel a shorthand is available:
+```
+/thread
+```
+
 Label a thread with a memorable name. The above command will open a channel called af8, but perhaps you want to call it "meetingnotes". To do so, select that buffer and type:
 ```
 /label meetingnotes

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3577,18 +3577,26 @@ def get_msg_from_id(channel, msg_id):
 @utf8_decode
 def command_thread(data, current_buffer, args):
     """
-    /thread <message_id>
+    /thread [message_id]
     Open the thread for the message.
+    If no message id is specified the last thread in channel will be opened.
     """
     channel = EVENTROUTER.weechat_controller.buffers[current_buffer]
-    if not args:
-        w.prnt('', 'Usage: /thread <id>')
-        return w.WEECHAT_RC_OK_EAT
 
-    msg = get_msg_from_id(channel, args)
-    if not msg:
-        w.prnt('', 'ERROR: Invalid id given, must be an existing id')
-        return w.WEECHAT_RC_OK_EAT
+    if args:
+        msg = get_msg_from_id(channel, args)
+        if not msg:
+            w.prnt('', 'ERROR: Invalid id given, must be an existing id')
+            return w.WEECHAT_RC_OK_EAT
+    else:
+        for message in reversed(channel.messages.values()):
+            if type(message) == SlackMessage and len(message.submessages) > 0:
+                msg = message
+                break
+        else:
+            w.prnt('', 'ERROR: No threads found in channel')
+            return w.WEECHAT_RC_OK_EAT
+
     msg.open_thread(switch=config.switch_buffer_on_join)
     return w.WEECHAT_RC_OK_EAT
 


### PR DESCRIPTION
Hey 👋 

Great plugin!

I had this idea and managed to hack something together: most of the time only the last thread in the channel is the most intriguing one and in those cases there's no need to type out a random id to access it.

This adds the ability to just type:
```
/thread
```
and the last thread in the current channel should be opened if found.