### PR TITLE
Upload file to thread instead of channel when in thread buffer

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3822,8 +3822,18 @@ def command_upload(data, current_buffer, args):
     # only http proxy is currenlty supported
     proxy = ProxyWrapper()
     proxy_string = proxy.curl()
-    command = 'curl -F file=@{} -F channels={} -F token={} {} {}'.format(
-            file_path, channel.identifier, channel.team.token, proxy_string, url)
+
+    form_fields = {
+        'file': '@' + file_path,
+        'channels': channel.identifier,
+        'token': channel.team.token,
+    }
+    if isinstance(channel, SlackThreadChannel):
+        form_fields['thread_ts'] = channel.parent_message.ts
+
+    curl_options = ' '.join(
+        '-F {}={}'.format(*field) for field in form_fields.iteritems())
+    command = 'curl {} {} {}'.format(curl_options, proxy_string, url)
     w.hook_process(command, config.slack_timeout, '', '')
     return w.WEECHAT_RC_OK_EAT
 


### PR DESCRIPTION
Currently files are always uploaded to the main channel, even when
`/slack upload` is run in a thread buffer. This happens because the
`thread_ts` field isn't included in the upload request.

Fixes #672