### PR TITLE
Fix /topic command output

### DIFF
--- a/_pytest/test_topic_command.py
+++ b/_pytest/test_topic_command.py
@@ -58,7 +58,7 @@ def test_call_topic_without_arguments(realish_eventrouter, channel_general):
         result = topic_command_cb(None, current_buffer, command)
         fake_prnt.assert_called_with(
             channel_general.channel_buffer,
-            'Topic for {} is "{}"'.format(channel_general.name, channel_general.topic),
+            'Topic for {} is "{}"'.format(channel_general.name, channel_general.topic['value']),
         )
         assert result == wee_slack.w.WEECHAT_RC_OK_EAT
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3489,7 +3489,7 @@ def topic_command_cb(data, current_buffer, command):
         return w.WEECHAT_RC_OK_EAT
 
     if topic is None:
-        w.prnt(channel.channel_buffer, 'Topic for {} is "{}"'.format(channel.name, channel.topic))
+        w.prnt(channel.channel_buffer, 'Topic for {} is "{}"'.format(channel.name, channel.topic['value']))
     else:
         s = SlackRequest(team.token, "channels.setTopic", {"channel": channel.identifier, "topic": topic}, team_hash=team.team_hash)
         EVENTROUTER.receive(s)


### PR DESCRIPTION
* This change makes sure the /topic command outputs
  'Topic for #random is ""' instead of
  'Topic for #random is "{'value': ''}"'.