### PR TITLE
Fix attachment fields without titles

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3336,7 +3336,7 @@ def unwrap_attachments(message_json, text_before):
             fields = attachment.get("fields")
             if fields:
                 for f in fields:
-                    if f['title'] != '':
+                    if f.get('title'):
                         t.append('%s %s' % (f['title'], f['value'],))
                     else:
                         t.append(f['value'])


### PR DESCRIPTION
Attachment fields are not guaranteed to have a title at all.

This fixes in particular slackbot app approval messages, with an
attachment like so:

```json
{
  "callback_id": "whitelist_A11BCGM0E_181389840855",
  "fields": [
    {
      "short": true,
      "value": ":white_check_mark: *<@U4RPXA42F|davo> approved this app for the team.*"
    }
  ],
  "fallback": "Approve or deny the application",
  "id": 4,
  "color": "#2ab27b"
}
```