### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Dependencies
 ------------
   * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
+    * Since WeeChat 2.6, Python 3 modules are required, see https://weechat.org/blog/post/2019/07/02/Python-3-by-default
   * Some distributions package weechat's plugin functionalities in separate packages.
     Be sure that your weechat supports python plugins. Under Debian, install `weechat-python`
 


### PR DESCRIPTION
It tooked me a while to figure out why weechat says that websocket module was not found in wee-slack plugin. 
pip list sayed websocket-client was installed.
after installing pip3 and websocket-client with pip3, everything worked fine. 
The current ubuntu 19.04 `python-websocket` package has always installed the python2.7 version.
The Dependencies should reflect this major change in weechat