### PR TITLE
Add implementation of slack layout blocks

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3390,7 +3390,7 @@ def unfurl_blocks(message_json):
             elif block["type"] == "context":
                 block_text.append("|".join(i["text"] for i in block["elements"]))
             else:
-                block_text.append(' {}<<Unsupported block type "{}">>{}'.format(w.color(config.color_reaction_suffix), block["type"], w.color("reset")))
+                block_text.append(' {}<<Unsupported block type "{}">>{}'.format(w.color(config.color_deleted), block["type"], w.color("reset")))
                 dbg('Unsupported block: "{}"'.format(json.dumps(block)), level=4)
         except Exception as e:
             dbg("Failed to unfurl block ({}): {}".format(repr(e), json.dumps(block)), level=4)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3379,7 +3379,7 @@ def unfurl_blocks(message_json):
     for block in message_json["blocks"]:
         try:
             if block["type"] == "section":
-                if "text" in block: block_text.append(block["text"]["text"])
+                if "text" in block: block_text += unfurl_texts([block["text"]])
                 if "fields" in block: block_text += unfurl_texts(block["fields"])
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
@@ -3389,7 +3389,7 @@ def unfurl_blocks(message_json):
                 block_text.append("|".join(i["text"] for i in block["elements"]))
             else:
                 block_text.append(json.dumps(block))
-        except KeyError as e:
+        except Exception as e:
             block_text.append(json.dumps(block) + repr(e))
     return "\n".join(block_text)
 
@@ -3397,7 +3397,11 @@ def unfurl_blocks(message_json):
 def unfurl_texts(texts):
     texts_ret = []
     for text in texts:
-        texts_ret.append(text["text"]) #TODO: markdown, etc. parse?
+        if text["type"] == "mrkdwn":
+            ftext = render_formatting(text["text"])
+        else:
+            ftext = text["text"]
+        texts_ret.append(ftext)
     return texts_ret
 
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3384,11 +3384,13 @@ def unfurl_blocks(message_json):
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
             elif block["type"] == "call":
-                block_text.append(". Join via ").append(block["call"]["v1"]["join_url"])
+                block_text.append(". Join via " + block["call"]["v1"]["join_url"])
             elif block["type"] == "divider":
                 block_text.append("\n")
             elif block["type"] == "context":
                 block_text.append("|".join(i["text"] for i in block["elements"]))
+            elif block["type"] == "rich_text":
+                continue
             else:
                 block_text.append(' {}<<Unsupported block type "{}">>{}'.format(w.color(config.color_deleted), block["type"], w.color("reset")))
                 dbg('Unsupported block: "{}"'.format(json.dumps(block)), level=4)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3383,6 +3383,8 @@ def unfurl_blocks(message_json):
                 if "fields" in block: block_text += unfurl_texts(block["fields"])
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+            elif block["type"] == "call":
+                block_text.append(". Join via ").append(block["call"]["v1"]["join_url"])
             elif block["type"] == "divider":
                 block_text.append("\n")
             elif block["type"] == "context":

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2474,11 +2474,11 @@ class SlackMessage(object):
         else:
             text = ""
 
-        if "blocks" in self.message_json:
-            text += unfurl_blocks(self.message_json)
-
         if self.message_json.get('mrkdwn', True):
             text = render_formatting(text)
+
+        if "blocks" in self.message_json:
+            text += unfurl_blocks(self.message_json)
 
         text = unfurl_refs(text)
 
@@ -3390,7 +3390,8 @@ def unfurl_blocks(message_json):
             elif block["type"] == "context":
                 block_text.append("|".join(i["text"] for i in block["elements"]))
             else:
-                raise NotImplementedError("Block type not implemented", block["type"])
+                block_text.append(' {}<<Unsupported block type "{}">>{}'.format(w.color(config.color_reaction_suffix), block["type"], w.color("reset")))
+                dbg('Unsupported block: "{}"'.format(json.dumps(block)), level=4)
         except Exception as e:
             dbg("Failed to unfurl block ({}): {}".format(repr(e), json.dumps(block)), level=4)
     return "\n".join(block_text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2474,6 +2474,9 @@ class SlackMessage(object):
         else:
             text = ""
 
+        if "blocks" in self.message_json:
+            text += unfurl_blocks(self.message_json)
+
         if self.message_json.get('mrkdwn', True):
             text = render_formatting(text)
 
@@ -3369,6 +3372,20 @@ def linkify_text(message, team, only_users=False):
 
     linkify_regex = r'(?:^|(?<=\s))([@#])([\w\(\)\'.-]+)'
     return re.sub(linkify_regex, linkify_word, message_escaped, re.UNICODE)
+
+
+def unfurl_blocks(message_json):
+    block_text = []
+    for block in message_json["blocks"]:
+        if block["type"] == "section":
+            block_text.append(block["text"]["text"]) #TODO: markdown, etc. parse?
+        if block["type"] == "actions":
+            block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+        if block["type"] == "divider":
+            block_text.append("\n")
+        if block["type"] == "context":
+            block_text.append("|".join(i["text"] for i in block["elements"]))
+    return "\n".join(block_text)
 
 
 def unfurl_refs(text, ignore_alt_text=None, auto_link_display=None):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3377,15 +3377,28 @@ def linkify_text(message, team, only_users=False):
 def unfurl_blocks(message_json):
     block_text = []
     for block in message_json["blocks"]:
-        if block["type"] == "section":
-            block_text.append(block["text"]["text"]) #TODO: markdown, etc. parse?
-        if block["type"] == "actions":
-            block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
-        if block["type"] == "divider":
-            block_text.append("\n")
-        if block["type"] == "context":
-            block_text.append("|".join(i["text"] for i in block["elements"]))
+        try:
+            if block["type"] == "section":
+                if "text" in block: block_text.append(block["text"]["text"])
+                if "fields" in block: block_text += unfurl_texts(block["fields"])
+            elif block["type"] == "actions":
+                block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+            elif block["type"] == "divider":
+                block_text.append("\n")
+            elif block["type"] == "context":
+                block_text.append("|".join(i["text"] for i in block["elements"]))
+            else:
+                block_text.append(json.dumps(block))
+        except KeyError as e:
+            block_text.append(json.dumps(block) + repr(e))
     return "\n".join(block_text)
+
+
+def unfurl_texts(texts):
+    texts_ret = []
+    for text in texts:
+        texts_ret.append(text["text"]) #TODO: markdown, etc. parse?
+    return texts_ret
 
 
 def unfurl_refs(text, ignore_alt_text=None, auto_link_display=None):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3390,9 +3390,9 @@ def unfurl_blocks(message_json):
             elif block["type"] == "context":
                 block_text.append("|".join(i["text"] for i in block["elements"]))
             else:
-                block_text.append(json.dumps(block))
+                raise NotImplementedError("Block type not implemented", block["type"])
         except Exception as e:
-            block_text.append(json.dumps(block) + repr(e))
+            dbg("Failed to unfurl block ({}): {}".format(repr(e), json.dumps(block)), level=4)
     return "\n".join(block_text)
 
 


### PR DESCRIPTION
See https://api.slack.com/reference/block-kit/blocks .

This is used by, among other things, the Polly poll bot, and fixes the issue I brought up in #667.

Is there a function I can use for rendering message formatting?  Right now the poll options include `*text*` and dates: `!date^1572642900^{date_short_pretty} at {time} (Today at 21:15 PM)`