### PR TITLE
Use Python3 websocket-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Setup
 
 **FreeBSD**: `pkg install py36-websocket-client`
 
-**OpenBSD**: `pkg_add weechat-python py-websocket-client`
+**OpenBSD**: `pkg_add weechat-python py3-websocket-client`
 
 **Other**: `pip install websocket-client`
 


### PR DESCRIPTION
When installing on OpenBSD, you need to specify the Python 3 version (not Python 2)