### PR TITLE
Add check_should_open call in the reconnect path.

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -432,6 +432,8 @@ class EventRouter(object):
                 team.set_disconnected()
             if not team.connected:
                 team.connect()
+                for c in team.channels.keys():
+                    team.channels[c].check_should_open()
                 dbg("reconnecting {}".format(team))
 
     def receive_ws_callback(self, team_hash):


### PR DESCRIPTION
This ensures that the history gets reloaded if
background_load_all_history is set to true.