### PR TITLE
manage unsupported block and rich text

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3324,13 +3324,15 @@ def unfurl_blocks(message_json):
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
             elif block["type"] == "call":
-                block_text.append(". Join via ").append(block["call"]["v1"]["join_url"])
+                block_text.append(". Join via " + block["call"]["v1"]["join_url"])
             elif block["type"] == "divider":
                 block_text.append("\n")
             elif block["type"] == "context":
                 block_text.append("|".join(i["text"] for i in block["elements"]))
+            elif block["type"] == "rich_text":
+                continue
             else:
-                block_text.append(json.dumps(block))
+                dbg("DEBUG: {}").format(json.dumps(block))
         except Exception as e:
             block_text.append(json.dumps(block) + repr(e))
     return "\n".join(block_text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3323,6 +3323,8 @@ def unfurl_blocks(message_json):
                 if "fields" in block: block_text += unfurl_texts(block["fields"])
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+            elif block["type"] == "call":
+                block_text.append(". Join via ").append(block["call"]["v1"]["join_url"])
             elif block["type"] == "divider":
                 block_text.append("\n")
             elif block["type"] == "context":

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3319,7 +3319,7 @@ def unfurl_blocks(message_json):
     for block in message_json["blocks"]:
         try:
             if block["type"] == "section":
-                if "text" in block: block_text.append(block["text"]["text"])
+                if "text" in block: block_text += unfurl_texts([block["text"]])
                 if "fields" in block: block_text += unfurl_texts(block["fields"])
             elif block["type"] == "actions":
                 block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
@@ -3329,7 +3329,7 @@ def unfurl_blocks(message_json):
                 block_text.append("|".join(i["text"] for i in block["elements"]))
             else:
                 block_text.append(json.dumps(block))
-        except KeyError as e:
+        except Exception as e:
             block_text.append(json.dumps(block) + repr(e))
     return "\n".join(block_text)
 
@@ -3337,7 +3337,11 @@ def unfurl_blocks(message_json):
 def unfurl_texts(texts):
     texts_ret = []
     for text in texts:
-        texts_ret.append(text["text"]) #TODO: markdown, etc. parse?
+        if text["type"] == "mrkdwn":
+            ftext = render_formatting(text["text"])
+        else:
+            ftext = text["text"]
+        texts_ret.append(ftext)
     return texts_ret
 
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2428,6 +2428,9 @@ class SlackMessage(object):
         else:
             text = ""
 
+        if "blocks" in self.message_json:
+            text += unfurl_blocks(self.message_json)
+
         if self.message_json.get('mrkdwn', True):
             text = render_formatting(text)
 
@@ -3309,6 +3312,20 @@ def linkify_text(message, team, only_users=False):
 
     linkify_regex = r'(?:^|(?<=\s))([@#])([\w\(\)\'.-]+)'
     return re.sub(linkify_regex, linkify_word, message_escaped, re.UNICODE)
+
+
+def unfurl_blocks(message_json):
+    block_text = []
+    for block in message_json["blocks"]:
+        if block["type"] == "section":
+            block_text.append(block["text"]["text"]) #TODO: markdown, etc. parse?
+        if block["type"] == "actions":
+            block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+        if block["type"] == "divider":
+            block_text.append("\n")
+        if block["type"] == "context":
+            block_text.append("|".join(i["text"] for i in block["elements"]))
+    return "\n".join(block_text)
 
 
 def unfurl_refs(text, ignore_alt_text=None, auto_link_display=None):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3317,15 +3317,28 @@ def linkify_text(message, team, only_users=False):
 def unfurl_blocks(message_json):
     block_text = []
     for block in message_json["blocks"]:
-        if block["type"] == "section":
-            block_text.append(block["text"]["text"]) #TODO: markdown, etc. parse?
-        if block["type"] == "actions":
-            block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
-        if block["type"] == "divider":
-            block_text.append("\n")
-        if block["type"] == "context":
-            block_text.append("|".join(i["text"] for i in block["elements"]))
+        try:
+            if block["type"] == "section":
+                if "text" in block: block_text.append(block["text"]["text"])
+                if "fields" in block: block_text += unfurl_texts(block["fields"])
+            elif block["type"] == "actions":
+                block_text.append("|".join(i["text"]["text"] for i in block["elements"]))
+            elif block["type"] == "divider":
+                block_text.append("\n")
+            elif block["type"] == "context":
+                block_text.append("|".join(i["text"] for i in block["elements"]))
+            else:
+                block_text.append(json.dumps(block))
+        except KeyError as e:
+            block_text.append(json.dumps(block) + repr(e))
     return "\n".join(block_text)
+
+
+def unfurl_texts(texts):
+    texts_ret = []
+    for text in texts:
+        texts_ret.append(text["text"]) #TODO: markdown, etc. parse?
+    return texts_ret
 
 
 def unfurl_refs(text, ignore_alt_text=None, auto_link_display=None):


### PR DESCRIPTION
I added support for reach_text block otherwise at the end of all
messages wee-slack was printing the raw JSON block.

I have also fixed the `call` block to print the right join url

I don't know if `dbg("DEBUG: {}").format(json.dumps(block))` this is the right way to do it but my plan here was to log in debug mode blocks that are not yet supported. If we prefer to print the raw JSON I can roll it back.