### PR TITLE
Allow subscribing to threads

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2508,8 +2508,8 @@ class SlackMessage(object):
 
         if self.number_of_replies():
             self.channel.hash_message(self.ts)
-            text += " " + colorize_string(get_thread_color(self.hash), "[ Thread: {} Replies: {} Subscribed: {} ]".format(
-                    self.hash, self.number_of_replies(), self.subscribed))
+            text += " " + colorize_string(get_thread_color(self.hash), "[ Thread: {} Replies: {}{} ]".format(
+                    self.hash, self.number_of_replies(), " Subscribed" if self.subscribed else ""))
 
         text = replace_string_with_emoji(text)
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2570,6 +2570,8 @@ class SlackMessage(object):
                 template = "New message in thread {hash}, channel {channel} in which you participated"
             elif action == "response":
                 template = "New message in thread {hash} in response to own message in {channel}"
+            elif action == "subscribed":
+                template = "New message in thread {hash}, channel {channel} to which you are subscribed"
             else:
                 template = "Notification for message in thread {hash}, channel {channel}"
             message = template.format(hash=self.hash, channel=self.channel.formatted_name())

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2240,6 +2240,8 @@ class SlackThreadChannel(SlackChannelCommon):
         self.members = self.parent_message.channel.members
         self.team = self.parent_message.team
         self.last_line_from = None
+        self.last_read = self.parent_message.message_json.get("last_read", SlackTS())
+        self.new_messages = False
 
     @property
     def identifier(self):
@@ -2266,32 +2268,42 @@ class SlackThreadChannel(SlackChannelCommon):
         self.rename()
 
     def mark_read(self, ts=None, update_remote=True, force=False):
-        if True or force: #TODO: Add check for new_messages here.
+        if self.new_messages or force:
             if self.channel_buffer:
                 w.buffer_set(self.channel_buffer, "unread", "")
                 w.buffer_set(self.channel_buffer, "hotlist", "-1")
             if not ts:
                 ts = next(reversed(self.messages), SlackTS())
+            if ts > self.last_read:
+                self.last_read = ts
             if update_remote:
                 s = SlackRequest(self.team, SLACK_API_TRANSLATOR[self.type]["mark"],
                         {"channel": self.identifier, "thread_ts": self.parent_message.ts, "ts": ts}, channel=self)
                 self.eventrouter.receive(s)
+                self.new_messages = False
 
     def buffer_prnt(self, nick, text, timestamp, tag_nick=None):
         data = "{}\t{}".format(format_nick(nick, self.last_line_from), text)
         self.last_line_from = nick
         ts = SlackTS(timestamp)
         if self.channel_buffer:
+            # backlog messages - we will update the read marker as we print these
+            backlog = ts <= self.last_read
+            if not backlog:
+                self.new_messages = True
+
             if self.parent_message.channel.type in ["im", "mpim"]:
                 tagset = "dm"
             else:
                 tagset = "channel"
+
+            no_log = backlog
             self_msg = tag_nick == self.team.nick
-            tags = tag(tagset, user=tag_nick, self_msg=self_msg)
+            tags = tag(tagset, user=tag_nick, self_msg=self_msg, backlog=backlog, no_log=no_log)
 
             w.prnt_date_tags(self.channel_buffer, ts.major, tags, data)
             modify_last_print_time(self.channel_buffer, ts.minor)
-            if self_msg:
+            if backlog or self_msg:
                 self.mark_read(ts, update_remote=False, force=True)
 
     def get_history(self):
@@ -3030,8 +3042,8 @@ def subprocess_thread_message(message_json, eventrouter, team, channel, history_
 
             if parent_message.thread_channel and parent_message.thread_channel.active:
                 parent_message.thread_channel.buffer_prnt(message.sender, parent_message.thread_channel.render(message), message.ts, tag_nick=message.sender_plain)
-            elif message.ts > channel.last_read and parent_message.subscribed:
-                parent_message.notify_thread(action="subscribed", sender_id=message_json["user"]) #TODO: Use thread last_read ts
+            elif message.ts > message.message_json.get("last_read", SlackTS()) and parent_message.subscribed:
+                parent_message.notify_thread(action="subscribed", sender_id=message_json["user"])
             elif message.ts > channel.last_read and message.has_mention():
                 parent_message.notify_thread(action="mention", sender_id=message_json["user"])
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3155,6 +3155,18 @@ process_im_marked = process_channel_marked
 process_mpim_marked = process_channel_marked
 
 
+def process_thread_marked(message_json, eventrouter, team, channel, metadata):
+    subscription = message_json.get("subscription", {})
+    ts = subscription.get("last_read")
+    thread_ts = subscription.get("thread_ts")
+    channel = team.channels.get(subscription.get("channel"))
+    if ts and thread_ts and channel:
+        thread_channel = channel.thread_channels.get(thread_ts)
+        if thread_channel: thread_channel.mark_read(ts=ts, force=True, update_remote=False)
+    else:
+        dbg("tried to mark something weird {}".format(message_json))
+
+
 def process_channel_joined(message_json, eventrouter, team, channel, metadata):
     channel.update_from_message_json(message_json["channel"])
     channel.open()

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -4177,6 +4177,7 @@ command_unsubscribe.completion = '%(threads)'
 
 def handle_subscriptionsthreadmark(json, eventrouter, team, channel, metadata):
     dbg(repr(json))
+    if not json["ok"]: w.prnt('', 'Failed to set subscription status.  Check debug log for details.')
 
 
 @slack_buffer_required

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3230,12 +3230,18 @@ def process_emoji_changed(message_json, eventrouter, team, channel, metadata):
 
 def process_thread_subscribed(message_json, eventrouter, team, channel, metadata):
     dbg("THREAD SUBSCRIBED {}".format(message_json))
-    team.channels[message_json["subscription"]["channel"]].messages.get(SlackTS(message_json["subscription"]["thread_ts"])).subscribed = True
+    channel = team.channels[message_json["subscription"]["channel"]]
+    parent_ts = message_json["subscription"]["thread_ts"]
+    channel.messages.get(SlackTS(parent_ts)).subscribed = True
+    channel.change_message(parent_ts)
 
 
 def process_thread_unsubscribed(message_json, eventrouter, team, channel, metadata):
     dbg("THREAD UNSUBSCRIBED {}".format(message_json))
-    team.channels[message_json["subscription"]["channel"]].messages.get(SlackTS(message_json["subscription"]["thread_ts"])).subscribed = False
+    channel = team.channels[message_json["subscription"]["channel"]]
+    parent_ts = message_json["subscription"]["thread_ts"]
+    channel.messages.get(SlackTS(parent_ts)).subscribed = False
+    channel.change_message(parent_ts)
 
 
 ###### New module/global methods

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2582,10 +2582,6 @@ class SlackMessage(object):
         elif sender_id != self.team.myidentifier:
             if action == "mention":
                 template = "You were mentioned in thread {hash}, channel {channel}"
-            elif action == "participant":
-                template = "New message in thread {hash}, channel {channel} in which you participated"
-            elif action == "response":
-                template = "New message in thread {hash} in response to own message in {channel}"
             elif action == "subscribed":
                 template = "New message in thread {hash}, channel {channel} to which you are subscribed"
             else:
@@ -3115,18 +3111,7 @@ subprocess_group_topic = subprocess_channel_topic
 
 
 def subprocess_message_replied(message_json, eventrouter, team, channel, history_message):
-    dbg("MESSAGE REPLIED {}".format(message_json))
-    parent_ts = message_json["message"].get("thread_ts")
-    parent_message = channel.messages.get(SlackTS(parent_ts))
-    # Thread exists but is not open yet
-    if parent_message is not None \
-            and not (parent_message.thread_channel and parent_message.thread_channel.active):
-        channel.hash_message(parent_ts)
-        last_message = max(message_json["message"]["replies"], key=lambda x: x["ts"])
-        if message_json["message"].get("user") == team.myidentifier:
-            parent_message.notify_thread(action="response", sender_id=last_message["user"])
-        elif any(team.myidentifier == r["user"] for r in message_json["message"]["replies"]):
-            parent_message.notify_thread(action="participant", sender_id=last_message["user"])
+    pass
 
 
 def subprocess_message_changed(message_json, eventrouter, team, channel, history_message):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1598,6 +1598,9 @@ class SlackChannelCommon(object):
             return self.messages[ts].hash
 
     def mark_read(self, ts=None, update_remote=True, force=False, post_data={}):
+        if config.thread_messages_in_channel and getattr(self, thread_channels):
+            for channel in self.thread_channels.values():
+                channel.mark_read(ts, update_remote, force, post_data)
         if self.new_messages or force:
             if self.channel_buffer:
                 w.buffer_set(self.channel_buffer, "unread", "")
@@ -2275,8 +2278,10 @@ class SlackThreadChannel(SlackChannelCommon):
     def refresh(self):
         self.rename()
 
-    def mark_read(self, ts=None, update_remote=True, force=False):
-        super(SlackThreadChannel, self).mark_read(ts=ts, update_remote=update_remote, force=force, post_data={"thread_ts": self.parent_message.ts})
+    def mark_read(self, ts=None, update_remote=True, force=False, post_data={}):
+        args = {"thread_ts": self.parent_message.ts}
+        args.update(post_data)
+        super(SlackThreadChannel, self).mark_read(ts=ts, update_remote=update_remote, force=force, post_data=args)
 
     def buffer_prnt(self, nick, text, timestamp, history_message=False, tag_nick=None):
         data = "{}\t{}".format(format_nick(nick, self.last_line_from), text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2881,6 +2881,21 @@ def handle_reactionsremove(json, eventrouter, team, channel, metadata):
         print_error("Couldn't remove reaction {}: {}".format(metadata['reaction'], json['error']))
 
 
+def handle_subscriptionsthreadmark(json, eventrouter, team, channel, metadata):
+    if not json["ok"]:
+        print_error("Couldn't set thread read status: {}", json['error'])
+
+
+def handle_subscriptionsthreadadd(json, eventrouter, team, channel, metadata):
+    if not json["ok"]:
+        print_error("Couldn't add thread subscription: {}", json['error'])
+
+
+def handle_subscriptionsthreadremove(json, eventrouter, team, channel, metadata):
+    if not json["ok"]:
+        print_error("Couldn't remove thread subscription: {}", json['error'])
+
+
 ###### New/converted process_ and subprocess_ methods
 def process_hello(message_json, eventrouter, team, channel, metadata):
     team.subscribe_users_presence()
@@ -4175,11 +4190,6 @@ def command_unsubscribe(data, current_buffer, args):
     return subscribe_helper(current_buffer, args, 'Usage: /slack unsubscribe <thread>', "subscriptions.thread.remove")
 
 command_unsubscribe.completion = '%(threads)'
-
-
-def handle_subscriptionsthreadmark(json, eventrouter, team, channel, metadata):
-    dbg(repr(json))
-    if not json["ok"]: w.prnt('', 'Failed to set subscription status.  Check debug log for details.')
 
 
 @slack_buffer_required

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1959,12 +1959,6 @@ class SlackChannel(SlackChannelCommon):
                 del self.typing[user]
         return typing
 
-    def mark_read(self, ts=None, update_remote=True, force=False, post_data={}):
-        if config.thread_messages_in_channel and update_remote:
-            for thread_channel in self.thread_channels.values():
-                thread_channel.mark_read(ts=ts, update_remote=update_remote, force=force, post_data=post_data)
-        super(SlackChannel, self).mark_read(ts=ts, update_remote=update_remote, force=force, post_data=post_data)
-
     def user_joined(self, user_id):
         # ugly hack - for some reason this gets turned into a list
         self.members = set(self.members)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3029,10 +3029,10 @@ def subprocess_thread_message(message_json, eventrouter, team, channel, history_
 
             if parent_message.thread_channel and parent_message.thread_channel.active:
                 parent_message.thread_channel.buffer_prnt(message.sender, parent_message.thread_channel.render(message), message.ts, history_message=history_message, tag_nick=message.sender_plain)
-            elif message.ts > message.message_json.get("last_read", SlackTS()) and parent_message.subscribed:
-                parent_message.notify_thread(action="subscribed", sender_id=message_json["user"])
             elif message.ts > channel.last_read and message.has_mention():
                 parent_message.notify_thread(action="mention", sender_id=message_json["user"])
+            elif message.ts > parent_message.message_json.get("last_read", SlackTS()) and parent_message.subscribed:
+                parent_message.notify_thread(action="subscribed", sender_id=message_json["user"])
 
             if config.thread_messages_in_channel or message_json["subtype"] == "thread_broadcast":
                 thread_tag = "thread_broadcast" if message_json["subtype"] == "thread_broadcast" else "thread_message"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1607,8 +1607,10 @@ class SlackChannelCommon(object):
             if ts > self.last_read:
                 self.last_read = ts
             if update_remote:
+                args = {"channel": self.identifier, "ts": ts}
+                args.update(post_data)
                 s = SlackRequest(self.team, SLACK_API_TRANSLATOR[self.type]["mark"],
-                        {"channel": self.identifier, "ts": ts, **post_data}, channel=self)
+                        args, channel=self)
                 self.eventrouter.receive(s)
                 self.new_messages = False
 
@@ -2267,7 +2269,7 @@ class SlackThreadChannel(SlackChannelCommon):
         self.rename()
 
     def mark_read(self, ts=None, update_remote=True, force=False):
-        super().mark_read(ts=ts, update_remote=update_remote, force=force, post_data={"thread_ts": self.parent_message.ts})
+        super(SlackThreadChannel, self).mark_read(ts=ts, update_remote=update_remote, force=force, post_data={"thread_ts": self.parent_message.ts})
 
     def buffer_prnt(self, nick, text, timestamp, history_message=False, tag_nick=None):
         data = "{}\t{}".format(format_nick(nick, self.last_line_from), text)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2893,17 +2893,17 @@ def handle_reactionsremove(json, eventrouter, team, channel, metadata):
 
 def handle_subscriptionsthreadmark(json, eventrouter, team, channel, metadata):
     if not json["ok"]:
-        print_error("Couldn't set thread read status: {}", json['error'])
+        print_error("Couldn't set thread read status: {}".format(json['error']))
 
 
 def handle_subscriptionsthreadadd(json, eventrouter, team, channel, metadata):
     if not json["ok"]:
-        print_error("Couldn't add thread subscription: {}", json['error'])
+        print_error("Couldn't add thread subscription: {}".format(json['error']))
 
 
 def handle_subscriptionsthreadremove(json, eventrouter, team, channel, metadata):
     if not json["ok"]:
-        print_error("Couldn't remove thread subscription: {}", json['error'])
+        print_error("Couldn't remove thread subscription: {}".format(json['error']))
 
 
 ###### New/converted process_ and subprocess_ methods


### PR DESCRIPTION
It currently seems to work on threads that are automatically subscribed
(such as by saying something in them or by subscribing in the slack web UI).

Does anyone know what the difference between thread_message and message_replied is?  They both have some processing of thread messages.