### PR TITLE
More robust handling of file modes

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3565,10 +3565,15 @@ def unwrap_attachments(message_json, text_before):
 def unwrap_files(message_json, text_before):
     files_texts = []
     for f in message_json.get('files', []):
-        if f.get('mode', '') != 'tombstone':
+        if f.get('mode', '') == 'tombstone':
+            text = colorize_string(config.color_deleted, '(This file was deleted.)')
+        elif f.get('mode', '') == 'hidden_by_limit':
+            text = colorize_string(config.color_deleted, '(This file is hidden because the workspace has passed its storage limit.)')
+        elif f.get('url_private', None) is not None and f.get('title', None) is not None:
             text = '{} ({})'.format(f['url_private'], f['title'])
         else:
-            text = colorize_string(config.color_deleted, '(This file was deleted.)')
+            dbg('File {} has unrecognized mode {}'.format(f['id'], f['mode']), 5)
+            text = colorize_string(config.color_deleted, '(This file cannot be handled.)')
         files_texts.append(text)
 
     if text_before:


### PR DESCRIPTION
Previously, files with a mode other than "tombstone" were assumed to have a
"title" and "private_url". This is not necessarily the case; in particular,
files with the "hidden_by_limit" (removed from visibility because the
workspace has exceeded its free-tier storage limit) mode have *only* "id" and
"mode". This resulted in a KeyError trying to look up the "title" and
"private_url", and truncated history at the message with that file.

This commit explicitly handles "hidden_by_limit" files, and makes the handling
of any other unknown modes more robust by explicitly checking for "title" and
"private_url" before rendering a message with them.