### PR TITLE
Fix usage of dates with non ASCII characters for Python 2

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3926,7 +3926,7 @@ def resolve_ref(ref):
                     else:
                         token = token.replace('_pretty', '')
                 if token in token_to_format:
-                    return ref_datetime.strftime(token_to_format[token])
+                    return decode_from_utf8(ref_datetime.strftime(token_to_format[token]))
                 else:
                     return match.group(0)
 


### PR DESCRIPTION
When not using english locale, date could contains non ASCII characters.

Fixes #419