### PR TITLE
Don't display the typing indicator for muted conversations

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1834,7 +1834,7 @@ class SlackChannel(SlackChannelCommon):
                 w.buffer_set(self.channel_buffer, "hotlist", "1")
 
     def formatted_name(self, style="default", typing=False, present=None):
-        show_typing = typing and config.channel_name_typing_indicator
+        show_typing = typing and not self.muted and config.channel_name_typing_indicator
         if style == "sidebar" and show_typing:
             prepend = ">"
         elif self.type == "group" or self.type == "private":


### PR DESCRIPTION
Well, the commit message is pretty obvious.

I actually noticed this as my terminal highlights the tab since there's new console output.