### PR TITLE
Add support to disable teammate link previews

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3791,6 +3791,8 @@ def unwrap_attachments(message_json, text_before):
             # $author: (if rest of line is non-empty) $title ($title_link) OR $from_url
             # $author: (if no $author on previous line) $text
             # $fields
+            if 'original_url' in attachment and not config.link_previews:
+               continue
             t = []
             prepend_title_text = ''
             if 'author_name' in attachment:
@@ -5364,6 +5366,9 @@ class PluginConfig(object):
             default='200',
             desc='The number of messages to fetch for each channel when fetching'
             ' history, between 1 and 1000.'),
+        'link_previews': Setting(
+            default='true',
+            desc='Show previews of website content linked by teammates.'),
         'map_underline_to': Setting(
             default='_',
             desc='When sending underlined text to slack, use this formatting'


### PR DESCRIPTION
This supersedes #529 and should finally close #526 .

To disable URL unfurling: `/set plugins.var.python.slack.link_previews "false"`, followed by a `/python reload` or a Slack channel close/reopen.

To re-enable, set to `"true"` and the same reload is required.