### PR TITLE
Update Docker image to use python3 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:latest
 
 RUN apk add --no-cache \
 	ca-certificates \
-	python \
+	python3 \
 	py-pip \
 	weechat \
 	weechat-perl \


### PR DESCRIPTION
The current Dockerfile fails to build as the latest alpine images no longer include a plain `python` package. This change installs the `python3` package instead. 