### PR TITLE
Don't unhide buffers when reprinting messages

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2413,6 +2413,7 @@ class SlackChannel(SlackChannelCommon):
                 config.unhide_buffers_with_activity
                 and not self.is_visible()
                 and not self.muted
+                and not no_log
             ):
                 w.buffer_set(self.channel_buffer, "hidden", "0")
 


### PR DESCRIPTION
I often manually hide buffers.  I don't want to mute them or mark them as distracting, because I still want them to pop up when they get a message, I just want them out of the hotlist/buflist for the time being.  The problem is that when wee-slack reconnects to Slack (usually several times per day), reprinting the messages causes all the buffers to get unhidden again, blowing out the buflist length.  This patch fixes that by avoiding unhiding for `no_log` messages.