### PR TITLE
Add `logger_history` tag when printing historical messages

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1875,7 +1875,7 @@ class SlackChannelCommon(object):
             w.prnt_date_tags(
                 self.channel_buffer,
                 ts.major,
-                tag(ts, backlog=True, no_log=True),
+                tag(ts, backlog=True, no_log=True, history_message=True),
                 "\tgetting channel history...",
             )
             w.buffer_set(self.channel_buffer, "print_hooks_enabled", "1")
@@ -2406,6 +2406,7 @@ class SlackChannel(SlackChannelCommon):
                 self_msg=self_msg,
                 backlog=backlog,
                 no_log=no_log,
+                history_message=history_message,
                 extra_tags=extra_tags,
             )
 
@@ -3029,6 +3030,7 @@ class SlackThreadChannel(SlackChannelCommon):
                 self_msg=self_msg,
                 backlog=backlog,
                 no_log=no_log,
+                history_message=history_message,
                 extra_tags=extra_tags,
             )
 
@@ -4886,6 +4888,7 @@ def tag(
     self_msg=False,
     backlog=False,
     no_log=False,
+    history_message=False,
     extra_tags=None,
 ):
     tagsets = {
@@ -4912,6 +4915,8 @@ def tag(
         tags = [
             tag for tag in tags if not tag.startswith("log") or tag == "logger_backlog"
         ]
+    if history_message:
+        tags += ["logger_history"]
     if extra_tags:
         tags += extra_tags
     return ",".join(OrderedDict.fromkeys(tags))


### PR DESCRIPTION
I have the default `beep` trigger installed, which rings the terminal bell on privmsgs and notify msgs.

```
trigger.trigger.beep.arguments    string   ""
trigger.trigger.beep.command      string   "/print -beep"
trigger.trigger.beep.conditions   string   "${tg_displayed} && (${tg_highlight} || ${tg_msg_pv})"
trigger.trigger.beep.enabled      boolean  on
trigger.trigger.beep.hook         integer  print
trigger.trigger.beep.post_action  integer  none
trigger.trigger.beep.regex        string   ""
trigger.trigger.beep.return_code  integer  ok
```

The problem is that when wee-slack reconnects to Slack (usually several times per day), reprinting the history messages causes this trigger to re-fire for all matching messages.  If I have a lot of unread priv/notify msgs, then this rings the bell a lot, which gets very annoying.

wee-slack disables `print_hooks_enabled` while printing the message, but only for `no_log`, and it seems that the messages are (also?) output with `no_log=False`, `history_message=True`, and `backlog=False` (preventing `no_log` from enabling).  I suppose disabling print hooks for `history_message=True` would be wrong, since then they might not fire when they should (eg. after being disconnected from Slack for a while).  However, even in this case, I still don't want the terminal bell to ring.

The solution I came up with is to add a `logger_history` tag when `history_message=True`, so that I can adjust the `beep` trigger condition to:

```
trigger.trigger.beep.conditions   string   "(${tg_tags} !~ ,logger_history,) && ${tg_displayed} && (${tg_highlight} || ${tg_msg_pv})"
```

This seems to work nicely - I still get terminal bells on notify/priv msgs like I should, but not when wee-slack connects initially or reconnects.