### PR TITLE
Validate token not empty, before initiate connection

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -6750,7 +6750,11 @@ if __name__ == "__main__":
             auto_connect = weechat.info_get("auto_connect", "") != "0"
 
             if auto_connect:
-                tokens = [token.strip() for token in config.slack_api_token.split(",")]
+                tokens = [
+                    token.strip()
+                    for token in config.slack_api_token.split(",")
+                    if token
+                ]
                 w.prnt(
                     "",
                     "Connecting to {} slack team{}.".format(


### PR DESCRIPTION
I continuously received this error, when started weechat:
```
AttributeError: 'NoneType' object has no attribute 'token'
```

Because tokens list was `['', '']`. And weechat tried initiate connections without tokens.

This small change fix this error.