### PR TITLE
Fix handling of (multiline) messages from non-ASCII nick

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -263,7 +263,8 @@ class WeechatWrapper(object):
     # number of spaces, so it aligns correctly.
     def prnt_date_tags(self, buffer, date, tags, message):
         prefix, _, _ = message.partition("\t")
-        prefix_spaces = " " * len(weechat.string_remove_color(prefix, ""))
+        prefix = weechat.string_remove_color(encode_to_utf8(prefix), "")
+        prefix_spaces = " " * weechat.strlen_screen(prefix)
         message = message.replace("\n", "\n{}\t".format(prefix_spaces))
         return self.wrap_for_utf8(self.wrapped_class.prnt_date_tags)(
             buffer, date, tags, message


### PR DESCRIPTION
An error occurs when:
- running on Python 2.7 (weechat 2.3 on Debian oldstable)
- someone's nick contains non-ASCII characters

Any messages from that person are not displayed, and the core buffer shows the error message:
```
python: wrong arguments for function "string_remove_color" (script: slack)
```

Apparently the reason for this is that on Python 2, `weechat.string_remove_color` fails when passed a Unicode string containing non-ASCII characters.

Moreover, if the string might contain combining characters, CJK, or emoji, then the `len()` of the string is not the same as its width.  `weechat.strlen_screen` should give the right answer, or at least weechat's best guess.
