### PR TITLE
Support new session tokens (xoxc tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ token (but not the token itself). If you're worried about this, you can use the
 8. Return to WeeChat and run `/slack register <token>:<cookie>`.
 9. Reload the script with `/python reload slack`.
 
+Note that in some cases it may be necessary to include the `d-s` cookie as
+well. If so, you can supply it in this format `<token>:d=<d_cookie>;d-s=<d-s_cookie>`.
+
 If you use Firefox, you can run the `extract_token_from_browser.py` script to
 get the tokens and cookies for all the teams you're logged into:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ token (but not the token itself). If you're worried about this, you can use the
 8. Return to WeeChat and run `/slack register <token>:<cookie>`.
 9. Reload the script with `/python reload slack`.
 
+Note that if you log in or out of any teams in your browser, the cookie will be
+invalidated, and you will have to update it.
+
 Note that in some cases it may be necessary to include the `d-s` cookie as
 well. If so, you can supply it in this format `<token>:d=<d_cookie>;d-s=<d-s_cookie>`.
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,12 @@ token (but not the token itself). If you're worried about this, you can use the
 1. Open and sign into the [Slack customization page](https://my.slack.com/customize). Check that you end up on the correct team.
 2. Open the developer console (`Ctrl+Shift+J`/`Cmd+Opt+J` in Chrome and `Ctrl+Shift+K`/`Cmd+Opt+K` in Firefox).
 3. Paste and run this code: `window.prompt("Session token:", TS.boot_data.api_token)`
-4. A prompt with the token will appear. Copy the token, return to WeeChat and run `/slack register <token>`.
-5. Reload the script with `/python reload slack`.
+4. A prompt with the token will appear. Copy the token.
+5. In the developer console go to Application in Chrome or Storage in Firefox.
+6. Expand Cookies and click on the domain.
+7. Find the cookie named `d` and copy the value.
+8. Return to WeeChat and run `/slack register <token>:<cookie>`.
+9. Reload the script with `/python reload slack`.
 
 #### Optional: Connecting to multiple teams
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ token (but not the token itself). If you're worried about this, you can use the
 8. Return to WeeChat and run `/slack register <token>:<cookie>`.
 9. Reload the script with `/python reload slack`.
 
+If you use Firefox, you can run the `extract_token_from_browser.py` script to
+get the tokens and cookies for all the teams you're logged into:
+
+```
+./extract_token_from_browser.py firefox
+```
+
 #### Optional: Connecting to multiple teams
 
 You can run the register command multiple times to connect to multiple teams.

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -12,7 +12,7 @@ from websocket import ABNF
 sys.path.append(".")
 
 import wee_slack  # noqa: E402
-from wee_slack import EventRouter, initiate_connection  # noqa: E402
+from wee_slack import EventRouter, SlackRequest  # noqa: E402
 
 
 class fakewebsocket(object):
@@ -45,7 +45,7 @@ def mock_websocket():
 def realish_eventrouter(mock_websocket, mock_weechat):
     e = EventRouter()
     wee_slack.EVENTROUTER = e
-    context = e.store_context(initiate_connection("xoxs-token"))
+    context = e.store_context(SlackRequest(None, "rtm.start", token="xoxs-token"))
     with open("_pytest/data/http/rtm.start.json") as rtmstartfile:
         if sys.version_info.major == 2:
             rtmstartdata = rtmstartfile.read().decode("utf-8")

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -51,7 +51,8 @@ def realish_eventrouter(mock_websocket, mock_weechat):
             rtmstartdata = rtmstartfile.read().decode("utf-8")
         else:
             rtmstartdata = rtmstartfile.read()
-        e.receive_httprequest_callback(context, "", 0, rtmstartdata, "")
+        response = "HTTP/2 200\r\n\r\n" + rtmstartdata
+        e.receive_httprequest_callback(context, "", 0, response, "")
     while len(e.queue):
         e.handle_next()
     for team in e.teams.values():

--- a/_pytest/test_topic_command.py
+++ b/_pytest/test_topic_command.py
@@ -97,7 +97,6 @@ def test_call_topic_with_channel_and_string(realish_eventrouter, channel_general
     assert request.request == "conversations.setTopic"
     assert request.post_data == {
         "channel": "C407ABS94",
-        "token": "xoxs-token",
         "topic": "new topic",
     }
     assert result == wee_slack.w.WEECHAT_RC_OK_EAT

--- a/extract_token_from_browser.py
+++ b/extract_token_from_browser.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+import sqlite3
+import sys
+
+parser = argparse.ArgumentParser(
+    description="Extract Slack tokens from the browser files"
+)
+parser.add_argument(
+    "browser", help="Which browser to extract from", metavar="<browser>"
+)
+args = parser.parse_args()
+
+if args.browser != "firefox":
+    print("Currently only firefox is supported by this script", file=sys.stderr)
+    sys.exit(1)
+
+if sys.platform.startswith("linux"):
+    firefox_path = Path.home().joinpath(".mozilla/firefox")
+elif sys.platform.startswith("darwin"):
+    firefox_path = Path.home().joinpath("Library/Application Support/Firefox/Profiles")
+else:
+    print("Currently only Linux and macOS is supported by this script", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    default_profile_path = next(firefox_path.glob("*.default-release"))
+except StopIteration:
+    print("Couldn't find the default profile for Firefox", file=sys.stderr)
+    sys.exit(1)
+
+cookies_path = default_profile_path.joinpath("cookies.sqlite")
+con = sqlite3.connect(f"file:{cookies_path}?immutable=1", uri=True)
+cookies_query = "SELECT value FROM moz_cookies WHERE host = '.slack.com' AND name = 'd'"
+cookie_d_value = con.execute(cookies_query).fetchone()[0]
+con.close()
+
+local_storage_path = default_profile_path.joinpath("webappsstore.sqlite")
+con = sqlite3.connect(f"file:{local_storage_path}?immutable=1", uri=True)
+local_storage_query = "SELECT value FROM webappsstore2 WHERE key = 'localConfig_v2'"
+local_config_str = con.execute(local_storage_query).fetchone()[0]
+con.close()
+
+local_config = json.loads(local_config_str)
+
+for team in local_config["teams"].values():
+    print(f"{team['name']}: /slack register {team['token']}:{cookie_d_value}")

--- a/extract_token_from_browser.py
+++ b/extract_token_from_browser.py
@@ -34,9 +34,20 @@ except StopIteration:
 
 cookies_path = default_profile_path.joinpath("cookies.sqlite")
 con = sqlite3.connect(f"file:{cookies_path}?immutable=1", uri=True)
-cookies_query = "SELECT value FROM moz_cookies WHERE host = '.slack.com' AND name = 'd'"
-cookie_d_value = con.execute(cookies_query).fetchone()[0]
+cookie_d_query = (
+    "SELECT value FROM moz_cookies WHERE host = '.slack.com' AND name = 'd'"
+)
+cookie_d_value = con.execute(cookie_d_query).fetchone()[0]
+cookie_ds_query = (
+    "SELECT value FROM moz_cookies WHERE host = '.slack.com' AND name = 'd-s'"
+)
+cookie_ds_values = con.execute(cookie_ds_query).fetchone()
 con.close()
+
+if cookie_ds_values:
+    cookie_value = f"d={cookie_d_value};d-s={cookie_ds_values[0]}"
+else:
+    cookie_value = cookie_d_value
 
 local_storage_path = default_profile_path.joinpath("webappsstore.sqlite")
 con = sqlite3.connect(f"file:{local_storage_path}?immutable=1", uri=True)
@@ -49,7 +60,6 @@ teams = [
     team for team in local_config["teams"].values() if not team["id"].startswith("E")
 ]
 register_commands = [
-    f"{team['name']}:\n/slack register {team['token']}:{cookie_d_value}"
-    for team in teams
+    f"{team['name']}:\n/slack register {team['token']}:{cookie_value}" for team in teams
 ]
 print("\n\n".join(register_commands))

--- a/extract_token_from_browser.py
+++ b/extract_token_from_browser.py
@@ -45,7 +45,11 @@ local_config_str = con.execute(local_storage_query).fetchone()[0]
 con.close()
 
 local_config = json.loads(local_config_str)
-
-for team in local_config["teams"].values():
-    if not team["id"].startswith("E"):
-        print(f"{team['name']}: /slack register {team['token']}:{cookie_d_value}")
+teams = [
+    team for team in local_config["teams"].values() if not team["id"].startswith("E")
+]
+register_commands = [
+    f"{team['name']}:\n/slack register {team['token']}:{cookie_d_value}"
+    for team in teams
+]
+print("\n\n".join(register_commands))

--- a/extract_token_from_browser.py
+++ b/extract_token_from_browser.py
@@ -47,4 +47,5 @@ con.close()
 local_config = json.loads(local_config_str)
 
 for team in local_config["teams"].values():
-    print(f"{team['name']}: /slack register {team['token']}:{cookie_d_value}")
+    if not team["id"].startswith("E"):
+        print(f"{team['name']}: /slack register {team['token']}:{cookie_d_value}")

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2896,7 +2896,7 @@ class SlackMPDMChannel(SlackChannel):
     """
 
     def __init__(self, eventrouter, team_users, myidentifier, **kwargs):
-        if "members" in kwargs:
+        if kwargs.get("members"):
             kwargs["name"] = self.name_from_members(
                 team_users, kwargs["members"], myidentifier
             )

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -6788,7 +6788,16 @@ def initiate_connection(token):
     def handle_initial(data_type):
         def handle(response_json, eventrouter, team, channel, metadata):
             if not response_json["ok"]:
-                initial_data["errors"].append(f'{data_type}: {response_json["error"]}')
+                if response_json["error"] == "user_is_restricted":
+                    w.prnt(
+                        "",
+                        "You are a restricted user in this team, "
+                        f"{data_type} not loaded",
+                    )
+                else:
+                    initial_data["errors"].append(
+                        f'{data_type}: {response_json["error"]}'
+                    )
                 initial_data["complete"][data_type] = True
                 create_team(token, initial_data)
                 return

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -4116,11 +4116,12 @@ def download_files(message_json, channel):
         for fileout in fileout_iter(os.path.join(download_location, filename)):
             if os.path.isfile(fileout):
                 continue
+            curl_options = SlackRequest(channel.team, "").options()
             w.hook_process_hashtable(
                 "url:" + f["url_private"],
                 {
+                    **curl_options,
                     "file_out": fileout,
-                    "httpheader": "Authorization: Bearer " + channel.team.token,
                 },
                 config.slack_timeout,
                 "",

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -926,8 +926,6 @@ def local_process_async_slack_api_request(request, event_router):
         params = {"useragent": "wee_slack {}".format(SCRIPT_VERSION)}
         request.tried()
         context = event_router.store_context(request)
-        # TODO: let flashcode know about this bug - i have to 'clear' the hashtable or retry requests fail
-        w.hook_process_hashtable("url:", params, config.slack_timeout, "", context)
         w.hook_process_hashtable(
             weechat_request,
             params,
@@ -5180,7 +5178,6 @@ def command_register(data, current_buffer, args):
         "client_id={}&client_secret={}&redirect_uri={}&code={}"
     ).format(CLIENT_ID, CLIENT_SECRET, redirect_uri, code)
     params = {"useragent": "wee_slack {}".format(SCRIPT_VERSION)}
-    w.hook_process_hashtable("url:", params, config.slack_timeout, "", "")
     w.hook_process_hashtable(
         "url:{}".format(uri), params, config.slack_timeout, "register_callback", ""
     )

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2584,7 +2584,7 @@ class SlackChannel(SlackChannelCommon):
         self.pending_history_requests.add(self.identifier)
         self.get_members()
 
-        post_data = {"channel": self.identifier, "count": config.history_fetch_count}
+        post_data = {"channel": self.identifier, "limit": config.history_fetch_count}
         if self.got_history and self.messages and not full:
             post_data["oldest"] = next(reversed(self.messages))
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -59,9 +59,9 @@ except ImportError:
     Reversible = object
 
 try:
-    from urllib.parse import quote, urlencode
+    from urllib.parse import quote, unquote, urlencode
 except ImportError:
-    from urllib import quote, urlencode
+    from urllib import quote, unquote, urlencode
 
 try:
     JSONDecodeError = json.JSONDecodeError
@@ -391,6 +391,15 @@ def format_exc_tb():
 def format_exc_only():
     etype, value, _ = sys.exc_info()
     return "".join(decode_from_utf8(traceback.format_exception_only(etype, value)))
+
+
+def url_encode_if_not_encoded(value):
+    decoded = unquote(value)
+    is_encoded = value != decoded
+    if is_encoded:
+        return value
+    else:
+        return quote(value)
 
 
 def get_localvar_type(slack_type):
@@ -1478,7 +1487,10 @@ class SlackRequest(object):
 
     def options(self):
         cookies = "; ".join(
-            ["{}={}".format(key, value) for key, value in self.cookies.items()]
+            [
+                "{}={}".format(key, url_encode_if_not_encoded(value))
+                for key, value in self.cookies.items()
+            ]
         )
         return {
             "useragent": "wee_slack {}".format(SCRIPT_VERSION),

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -6941,12 +6941,12 @@ def initiate_connection(token):
 def create_channel_from_info(eventrouter, channel_info, team, myidentifier, users):
     if channel_info.get("is_im"):
         return SlackDMChannel(eventrouter, users, team=team, **channel_info)
-    elif channel_info.get("is_shared"):
-        return SlackSharedChannel(eventrouter, team=team, **channel_info)
     elif channel_info.get("is_mpim"):
         return SlackMPDMChannel(
             eventrouter, users, myidentifier, team=team, **channel_info
         )
+    elif channel_info.get("is_shared"):
+        return SlackSharedChannel(eventrouter, team=team, **channel_info)
     elif channel_info.get("is_private"):
         return SlackPrivateChannel(eventrouter, team=team, **channel_info)
     else:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -923,12 +923,11 @@ def local_process_async_slack_api_request(request, event_router):
                 random.choice(string.ascii_uppercase + string.digits) for _ in range(4)
             )
         )
-        params = {"useragent": "wee_slack {}".format(SCRIPT_VERSION)}
         request.tried()
         context = event_router.store_context(request)
         w.hook_process_hashtable(
             weechat_request,
-            params,
+            request.options(),
             config.slack_timeout,
             "receive_httprequest_callback",
             context,
@@ -1429,6 +1428,7 @@ class SlackRequest(object):
         metadata=None,
         retries=3,
         token=None,
+        cookies=None,
         callback=None,
     ):
         if team is None and token is None:
@@ -1440,6 +1440,7 @@ class SlackRequest(object):
         self.metadata = metadata if metadata else {}
         self.retries = retries
         self.token = token if token else team.token
+        self.cookies = cookies or {}
         self.callback = callback
         self.domain = "api.slack.com"
         self.reset()
@@ -1448,29 +1449,45 @@ class SlackRequest(object):
         self.tries = 0
         self.start_time = time.time()
         self.request_normalized = re.sub(r"\W+", "", self.request)
-        self.post_data["token"] = self.token
         self.url = "https://{}/api/{}?{}".format(
             self.domain, self.request, urlencode(encode_to_utf8(self.post_data))
         )
-        self.params = {"useragent": "wee_slack {}".format(SCRIPT_VERSION)}
         self.response_id = sha1_hex("{}{}".format(self.url, self.start_time))
 
     def __repr__(self):
         return (
             "SlackRequest(team={}, request='{}', post_data={}, retries={}, token='{}', "
-            "tries={}, start_time={})"
+            "cookies={}, tries={}, start_time={})"
         ).format(
             self.team,
             self.request,
             self.post_data,
             self.retries,
             token_for_print(self.token),
+            self.cookies,
             self.tries,
             self.start_time,
         )
 
     def request_string(self):
         return "{}".format(self.url)
+
+    def options(self):
+        cookies = "; ".join(
+            ["{}={}".format(key, value) for key, value in self.cookies.items()]
+        )
+        return {
+            "useragent": "wee_slack {}".format(SCRIPT_VERSION),
+            "httpheader": "Authorization: Bearer {}".format(self.token),
+            "cookie": cookies,
+        }
+
+    def options_as_cli_args(self):
+        options = self.options()
+        options["user-agent"] = options.pop("useragent")
+        httpheader = options.pop("httpheader")
+        headers = [": ".join(x) for x in options.items()] + httpheader.split("\n")
+        return ["-H{}".format(header) for header in headers]
 
     def tried(self):
         self.tries += 1
@@ -5866,10 +5883,12 @@ def command_upload(data, current_buffer, args):
     if isinstance(channel, SlackThreadChannel):
         post_data["thread_ts"] = channel.thread_ts
 
-    url = SlackRequest(
-        channel.team, "files.upload", post_data, channel=channel
-    ).request_string()
-    options = ["-s", "-Ffile=@{}".format(file_path), url]
+    request = SlackRequest(channel.team, "files.upload", post_data, channel=channel)
+    options = request.options_as_cli_args() + [
+        "-s",
+        "-Ffile=@{}".format(file_path),
+        request.request_string(),
+    ]
 
     proxy_string = ProxyWrapper().curl()
     if proxy_string:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1441,6 +1441,10 @@ class SlackRequest(object):
         self.retries = retries
         self.token = token if token else team.token
         self.cookies = cookies or {}
+        if ":" in self.token:
+            token, cookie = self.token.split(":", 1)
+            self.token = token
+            self.cookies["d"] = cookie
         self.callback = callback
         self.domain = "api.slack.com"
         self.reset()
@@ -7029,5 +7033,13 @@ if __name__ == "__main__":
                     ),
                 )
                 for t in tokens:
-                    initiate_connection(t)
+                    if t.startswith("xoxc-") and ":" not in t:
+                        w.prnt(
+                            "",
+                            "{}When using an xoxc token, you need to also provide the d cookie in the format token:cookie".format(
+                                w.prefix("error")
+                            ),
+                        )
+                    else:
+                        initiate_connection(t)
                 EVENTROUTER.handle_next()

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1453,7 +1453,11 @@ class SlackRequest(object):
         if ":" in self.token:
             token, cookie = self.token.split(":", 1)
             self.token = token
-            self.cookies["d"] = cookie
+            if cookie.startswith("d="):
+                for name, value in [c.split("=") for c in cookie.split(";")]:
+                    self.cookies[name] = value
+            else:
+                self.cookies["d"] = cookie
         self.callback = callback
         self.domain = "api.slack.com"
         self.reset()

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -623,7 +623,7 @@ class EventRouter(object):
                 )
                 team.set_disconnected()
             if not team.connected:
-                team.connect(reconnect=True)
+                team.connect()
                 dbg("reconnecting {}".format(team))
 
     @utf8_decode
@@ -810,10 +810,12 @@ class EventRouter(object):
                     team = request.team
                     channel = request.channel
                     metadata = request.metadata
+                    callback = request.callback
                 else:
                     team = j.get("wee_slack_metadata_team")
                     channel = None
                     metadata = {}
+                    callback = None
 
                 if team:
                     if "channel" in j:
@@ -830,7 +832,9 @@ class EventRouter(object):
                         metadata["user"] = team.users.get(user_id)
 
                 dbg("running {}".format(function_name))
-                if (
+                if callable(callback):
+                    callback(j, self, team, channel, metadata)
+                elif (
                     function_name.startswith("local_")
                     and function_name in self.local_proc
                 ):
@@ -1427,6 +1431,7 @@ class SlackRequest(object):
         metadata=None,
         retries=3,
         token=None,
+        callback=None,
     ):
         if team is None and token is None:
             raise ValueError("Both team and token can't be None")
@@ -1437,10 +1442,14 @@ class SlackRequest(object):
         self.metadata = metadata if metadata else {}
         self.retries = retries
         self.token = token if token else team.token
+        self.callback = callback
+        self.domain = "api.slack.com"
+        self.reset()
+
+    def reset(self):
         self.tries = 0
         self.start_time = time.time()
-        self.request_normalized = re.sub(r"\W+", "", request)
-        self.domain = "api.slack.com"
+        self.request_normalized = re.sub(r"\W+", "", self.request)
         self.post_data["token"] = self.token
         self.url = "https://{}/api/{}?{}".format(
             self.domain, self.request, urlencode(encode_to_utf8(self.post_data))
@@ -1685,7 +1694,7 @@ class SlackTeam(object):
     def mark_read(self, ts=None, update_remote=True, force=False):
         pass
 
-    def connect(self, reconnect=False):
+    def connect(self):
         if not self.connected and not self.connecting_ws:
             if self.ws_url:
                 self.connecting_ws = True
@@ -1737,9 +1746,7 @@ class SlackTeam(object):
                 # The fast reconnect failed, so start over-ish
                 for chan in self.channels:
                     self.channels[chan].history_needs_update = True
-                s = initiate_connection(
-                    self.token, retries=999, team=self, reconnect=reconnect
-                )
+                s = get_rtm_connect_request(self.token, retries=999, team=self)
                 self.eventrouter.receive(s)
                 self.connecting_rtm = True
 
@@ -3243,7 +3250,7 @@ class SlackBot(SlackUser):
     """
 
     def __init__(self, originating_team_id, **kwargs):
-        super(SlackBot, self).__init__(originating_team_id, is_bot=True, **kwargs)
+        super(SlackBot, self).__init__(originating_team_id, **kwargs)
 
 
 class SlackMessage(object):
@@ -3689,7 +3696,7 @@ def handle_rtmstart(login_data, eventrouter, team, channel, metadata):
             t.set_reconnect_url(login_data["url"])
             t.connecting_rtm = False
 
-    t.connect(metadata.metadata["reconnect"])
+    t.connect()
 
 
 def handle_rtmconnect(login_data, eventrouter, team, channel, metadata):
@@ -3707,7 +3714,7 @@ def handle_rtmconnect(login_data, eventrouter, team, channel, metadata):
         return
 
     team.set_reconnect_url(login_data["url"])
-    team.connect(metadata.metadata["reconnect"])
+    team.connect()
 
 
 def handle_emojilist(emoji_json, eventrouter, team, channel, metadata):
@@ -6687,19 +6694,248 @@ def trace_calls(frame, event, arg):
     return
 
 
-def initiate_connection(token, retries=3, team=None, reconnect=False):
-    request_type = "connect" if team else "start"
-    post_data = {"batch_presence_aware": 1}
-    if request_type == "start":
-        post_data["mpim_aware"] = "true"
+def get_rtm_connect_request(token, retries=3, team=None, callback=None):
     return SlackRequest(
         team,
-        "rtm.{}".format(request_type),
-        post_data,
+        "rtm.connect",
+        {"batch_presence_aware": 1},
         retries=retries,
         token=token,
-        metadata={"reconnect": reconnect},
+        callback=callback,
     )
+
+
+def get_next_page(response_json):
+    next_cursor = response_json.get("response_metadata", {}).get("next_cursor")
+    if next_cursor:
+        request = response_json["wee_slack_request_metadata"]
+        request.post_data["cursor"] = next_cursor
+        request.reset()
+        EVENTROUTER.receive(request)
+        return True
+    else:
+        return False
+
+
+def initiate_connection(token):
+    initial_data = {
+        "channels": [],
+        "members": [],
+        "usergroups": [],
+        "complete": {
+            "channels": False,
+            "members": False,
+            "usergroups": False,
+            "prefs": False,
+            "presence": False,
+        },
+    }
+
+    def handle_initial(data_type):
+        def handle(response_json, eventrouter, team, channel, metadata):
+            if not response_json["ok"]:
+                initial_data["error"] = response_json["error"]
+                initial_data["complete"][data_type] = True
+                create_team(token, initial_data)
+                return
+
+            initial_data[data_type].extend(response_json[data_type])
+
+            if not get_next_page(response_json):
+                initial_data["complete"][data_type] = True
+                create_team(token, initial_data)
+
+        return handle
+
+    def handle_prefs(response_json, eventrouter, team, channel, metadata):
+        if not response_json["ok"]:
+            initial_data["error"] = response_json["error"]
+            initial_data["complete"]["prefs"] = True
+            create_team(token, initial_data)
+            return
+
+        initial_data["prefs"] = response_json["prefs"]
+        initial_data["complete"]["prefs"] = True
+        create_team(token, initial_data)
+
+    def handle_getPresence(response_json, eventrouter, team, channel, metadata):
+        if not response_json["ok"]:
+            initial_data["error"] = response_json["error"]
+            initial_data["complete"]["presence"] = True
+            create_team(token, initial_data)
+            return
+
+        initial_data["presence"] = response_json
+        initial_data["complete"]["presence"] = True
+        create_team(token, initial_data)
+
+    s = SlackRequest(
+        None,
+        "conversations.list",
+        {
+            "exclude_archived": True,
+            "types": "public_channel,private_channel,mpim,im",
+            "limit": 1000,
+        },
+        token=token,
+        callback=handle_initial("channels"),
+    )
+    EVENTROUTER.receive(s)
+    s = SlackRequest(
+        None,
+        "users.list",
+        {"limit": 1000},
+        token=token,
+        callback=handle_initial("members"),
+    )
+    EVENTROUTER.receive(s)
+    s = SlackRequest(
+        None,
+        "usergroups.list",
+        {"include_users": True},
+        token=token,
+        callback=handle_initial("usergroups"),
+    )
+    EVENTROUTER.receive(s)
+    s = SlackRequest(
+        None,
+        "users.prefs.get",
+        token=token,
+        callback=handle_prefs,
+    )
+    EVENTROUTER.receive(s)
+    s = SlackRequest(
+        None,
+        "users.getPresence",
+        token=token,
+        callback=handle_getPresence,
+    )
+    EVENTROUTER.receive(s)
+
+
+def create_team(token, initial_data):
+    if all(initial_data["complete"].values()):
+        if "error" in initial_data:
+            w.prnt(
+                "",
+                "ERROR: Failed connecting to Slack with token {}: {}".format(
+                    token_for_print(token), initial_data["error"]
+                ),
+            )
+            if not re.match(r"^xo\w\w(-\d+){3}-[0-9a-f]+(:.*)?$", token):
+                w.prnt(
+                    "",
+                    "ERROR: Token does not look like a valid Slack token. "
+                    "Ensure it is a valid token and not just a OAuth code.",
+                )
+
+            return
+
+        def handle_rtmconnect(response_json, eventrouter, team, channel, metadata):
+            if not response_json["ok"]:
+                print(response_json["error"])
+                return
+
+            team_id = response_json["team"]["id"]
+            myidentifier = response_json["self"]["id"]
+
+            users = {}
+            bots = {}
+            for member in initial_data["members"]:
+                if member.get("is_bot"):
+                    bots[member["id"]] = SlackBot(team_id, **member)
+                else:
+                    users[member["id"]] = SlackUser(team_id, **member)
+
+            self_nick = nick_from_profile(
+                users[myidentifier].profile, response_json["self"]["name"]
+            )
+
+            channels = {}
+            for channel in initial_data["channels"]:
+                if channel.get("is_im"):
+                    channel_instance = SlackDMChannel(
+                        eventrouter, users, is_member=True, **channel
+                    )
+                elif channel.get("is_shared"):
+                    channel_instance = SlackSharedChannel(eventrouter, **channel)
+                elif channel.get("is_mpim"):
+                    channel_instance = SlackMPDMChannel(
+                        eventrouter, users, myidentifier, **channel
+                    )
+                elif channel.get("is_private"):
+                    channel_instance = SlackPrivateChannel(eventrouter, **channel)
+                else:
+                    channel_instance = SlackChannel(eventrouter, **channel)
+                channels[channel["id"]] = channel_instance
+
+            subteams = {}
+            for usergroup in initial_data["usergroups"]:
+                is_member = myidentifier in usergroup["users"]
+                subteams[usergroup["id"]] = SlackSubteam(
+                    team_id, is_member=is_member, **usergroup
+                )
+
+            manual_presence = (
+                "away" if initial_data["presence"]["manual_away"] else "active"
+            )
+
+            team_info = {
+                "id": team_id,
+                "name": response_json["team"]["id"],
+                "domain": response_json["team"]["domain"],
+            }
+
+            team_hash = SlackTeam.generate_team_hash(
+                team_id, response_json["team"]["domain"]
+            )
+            if not eventrouter.teams.get(team_hash):
+                team = SlackTeam(
+                    eventrouter,
+                    token,
+                    team_hash,
+                    response_json["url"],
+                    team_info,
+                    subteams,
+                    self_nick,
+                    myidentifier,
+                    manual_presence,
+                    users,
+                    bots,
+                    channels,
+                    muted_channels=initial_data["prefs"]["muted_channels"],
+                    highlight_words=initial_data["prefs"]["highlight_words"],
+                )
+                eventrouter.register_team(team)
+                team.connect()
+            else:
+                team = eventrouter.teams.get(team_hash)
+                if team.myidentifier != myidentifier:
+                    print_error(
+                        "The Slack team {} has tokens for two different users, this is not supported. The "
+                        "token {} is for user {}, and the token {} is for user {}. Please remove one of "
+                        "them.".format(
+                            team.team_info["name"],
+                            token_for_print(team.token),
+                            team.nick,
+                            token_for_print(token),
+                            self_nick,
+                        )
+                    )
+                else:
+                    print_error(
+                        "Ignoring duplicate Slack tokens for the same team ({}) and user ({}). The two "
+                        "tokens are {} and {}.".format(
+                            team.team_info["name"],
+                            team.nick,
+                            token_for_print(team.token),
+                            token_for_print(token),
+                        ),
+                        warning=True,
+                    )
+
+        s = get_rtm_connect_request(token, callback=handle_rtmconnect)
+        EVENTROUTER.receive(s)
 
 
 if __name__ == "__main__":
@@ -6777,6 +7013,5 @@ if __name__ == "__main__":
                     ),
                 )
                 for t in tokens:
-                    s = initiate_connection(t)
-                    EVENTROUTER.receive(s)
+                    initiate_connection(t)
                 EVENTROUTER.handle_next()


### PR DESCRIPTION
This adds support for using the new type of session tokens (the ones starting with `xoxc`) that has replaced the old one.

To use such tokens, you also have to provide the `d` cookie from the browser. Currently this is specified after the token in `slack_api_key`, separated by a colon, e.g. `xoxc-token1:cookie,xoxp-token2`. The way to specify this may (hopefully will) change in the future.

Fixes #844


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#844: Session tokens no longer working](https://issuehunt.io/repos/18410202/issues/844)
---
</details>
<!-- /Issuehunt content-->