### PR TITLE
feat(display): Add URL when slack block contain URL

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -4430,6 +4430,8 @@ def unfurl_blocks(blocks):
                 for element in block["elements"]:
                     if element["type"] == "button":
                         elements.append(unfurl_block_element(element["text"]))
+                        if "url" in element:
+                             elements.append(element["url"])
                     else:
                         elements.append(
                             colorize_string(


### PR DESCRIPTION
When slack return a button message type and a url field is present we
should output the URL.

Fix: #811 and #810