### PR TITLE
extract_token_from_browser: widen default profile check

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ get the tokens and cookies for all the teams you're logged into:
 ./extract_token_from_browser.py firefox
 ```
 
+(Note this script requires the python3-snappy library.)
+
 #### Optional: Connecting to multiple teams
 
 You can run the register command multiple times to connect to multiple teams.

--- a/extract_token_from_browser.py
+++ b/extract_token_from_browser.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from configparser import ConfigParser
 import json
 from pathlib import Path
 import sqlite3
@@ -26,9 +27,21 @@ else:
     print("Currently only Linux and macOS is supported by this script", file=sys.stderr)
     sys.exit(1)
 
-try:
-    default_profile_path = next(firefox_path.glob("*.default-release"))
-except StopIteration:
+profile_path = firefox_path.joinpath("profiles.ini")
+profile_data = ConfigParser()
+profile_data.read(profile_path)
+
+default_profile_path = None
+for key in profile_data.sections():
+    if not key.startswith("Install"):
+        continue
+
+    value = profile_data[key]
+    if "Default" in value:
+        default_profile_path = firefox_path.joinpath(value["Default"])
+        break
+
+if default_profile_path is None:
     print("Couldn't find the default profile for Firefox", file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
On the Linux machines I've used, the default profile is suffixed .default, not .default-release.  I'm not sure what systems use .default-release, but preserving it for compatibility seems harmless.

This is actually not enough to get it working for me.  It bails later on: webappsstore.sqlite doesn't have anything with key "localConfig_v2", or anything that even looks like it.  System is firefox 110 on Debian testing.