### PR TITLE
docker: Update script path for wee_slack.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install websocket-client
 
 ENV HOME /home/user
 
-COPY wee_slack.py /home/user/.weechat/python/autoload/wee_slack.py
+COPY wee_slack.py /home/user/.local/share/weechat/python/autoload/wee_slack.py
 
 RUN adduser -S user -h $HOME \
 	&& chown -R user $HOME


### PR DESCRIPTION
I think the path has changed in the intervening years since this dockerfile was last edited; this new fix appears to work just fine in my tests.