### PR TITLE
feat: Filter channel list based on regular expression

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -5626,14 +5626,16 @@ def command_teams(data, current_buffer, args):
 @utf8_decode
 def command_channels(data, current_buffer, args):
     """
-    /slack channels
+    /slack channels [regex]
     List the channels in the current team.
+    If regex is given show channels whose names match the regular expression.
     """
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
+    pat = re.compile(args)
     channels = [
         channel
         for channel in team.channels.values()
-        if channel.type not in ["im", "mpim"]
+        if channel.type not in ["im", "mpim"] and pat.search(channel.name)
     ]
 
     def extra_info_function(channel):
@@ -5644,7 +5646,10 @@ def command_channels(data, current_buffer, args):
         else:
             return "not a member"
 
-    return print_team_items_info(team, "Channels", channels, extra_info_function)
+    if args:
+        return print_team_items_info(team, "Channels that match \"" + args + "\"", channels, extra_info_function)
+    else:
+        return print_team_items_info(team, "Channels", channels, extra_info_function)
 
 
 @slack_buffer_required

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -5647,7 +5647,9 @@ def command_channels(data, current_buffer, args):
             return "not a member"
 
     if args:
-        return print_team_items_info(team, "Channels that match \"" + args + "\"", channels, extra_info_function)
+        return print_team_items_info(
+            team, 'Channels that match "' + args + '"', channels, extra_info_function
+        )
     else:
         return print_team_items_info(team, "Channels", channels, extra_info_function)
 


### PR DESCRIPTION
It can be difficult to find a specific channel if there are thousands of them in your slack workspace.  This enhancement allows you to filter the channels based on a regular expression.  For example:

`/slack channels support`

returns
```
Channels that match "support":
    #customer-support    (not a member)
    #it-support-team     (not a member)
    #technnical-support  (member)
```
