### PR TITLE
Make render_emoji_as_string = "both" work with rich_text blocks

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -152,6 +152,8 @@ class FakeWeechat:
     def info_get(self, info_name, arguments):
         if info_name == "color_rgb2term":
             return arguments
+        elif info_name == "weechat_data_dir":
+            return "."
         else:
             return ""
 

--- a/_pytest/test_render_message.py
+++ b/_pytest/test_render_message.py
@@ -1,0 +1,100 @@
+import pytest
+
+import wee_slack
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {
+            "input_message": {
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "block_id": "5Cg6",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "emoji",
+                                        "name": "smile",
+                                        "unicode": "1f604",
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "reactions": [{"name": "eyes", "users": ["U01E8P3JKM1"], "count": 1}],
+            },
+            "rendered": (
+                # Should be just <emoji>
+                "\U0001f604 <[color darkgray]>[\U0001f4401]<[color reset]>"
+            ),
+        },
+        {
+            "input_message": {
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "block_id": "5Cg6",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "emoji",
+                                        "name": "smile",
+                                        "unicode": "1f604",
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "reactions": [{"name": "eyes", "users": ["U01E8P3JKM1"], "count": 1}],
+            },
+            "rendered": (
+                # Should be just :<emoji name>:
+                ":smile: <[color darkgray]>[:eyes:1]<[color reset]>"
+            ),
+            "render_emoji_as_string": True,
+        },
+        {
+            "input_message": {
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "block_id": "5Cg6",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "emoji",
+                                        "name": "smile",
+                                        "unicode": "1f604",
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "reactions": [{"name": "eyes", "users": ["U01E8P3JKM1"], "count": 1}],
+            },
+            "rendered": (
+                # Should be <emoji> (:<emoji name>:)
+                "\U0001f604 (:smile:) <[color darkgray]>[\U0001f440 (:eyes:)1]<[color reset]>"
+            ),
+            "render_emoji_as_string": "both",
+        },
+    ],
+)
+def test_render_message(case, channel_general):
+    wee_slack.EMOJI, wee_slack.EMOJI_WITH_SKIN_TONES_REVERSE = wee_slack.load_emoji()
+    wee_slack.config.render_emoji_as_string = case.get("render_emoji_as_string")
+    message_json = {"ts": str(wee_slack.SlackTS()), **case["input_message"]}
+    message = wee_slack.SlackMessage("normal", message_json, channel_general)
+    result = message.render()
+    assert result == case["rendered"]

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -3443,7 +3443,10 @@ class SlackMessage(object):
                 ),
             )
 
-        text = replace_string_with_emoji(text)
+        # replace_string_with_emoji() was called on blocks earlier via
+        # unfurl_blocks(), so exclude them here
+        text_to_replace = text[len(blocks_rendered) :]
+        text = text[: len(blocks_rendered)] + replace_string_with_emoji(text_to_replace)
 
         self.message_json["_rendered_text"] = text
         return text


### PR DESCRIPTION
Commit 74da30342e8d328fc085d2158e37afda3b908f2c added support for using rich_text blocks to format messages. With this change, the use of replace_string_with_emoji() for text type "emoji" can result in running the replacement twice as replace_string_with_emoji() is also called as one of the last steps in SlackMessage.render().

This works fine in the default case when render_emoji_as_string = "", however render_emoji_as_string = "both" results in output like:
  
  `😄 (😄 (:smile:))`

instead of the intended:

  `😄 (:smile:)`

This skips the second call of replace_string_with_emoji() if blocks were rendered earlier in the method.