### PR TITLE
Handle millisecond-level timestamps in attachments

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -4978,6 +4978,11 @@ def unwrap_attachments(message, text_before):
                 ts = attachment.get("ts")
                 if ts:
                     ts_int = ts if isinstance(ts, int) else SlackTS(ts).major
+                    if ts_int > 100000000000:
+                        # The Slack web interface interprets very large timestamps
+                        # as milliseconds after the epoch instead of regular Unix
+                        # timestamps. We use the same heuristic here.
+                        ts_int = ts_int // 1000
                     time_string = ""
                     if date.today() - date.fromtimestamp(ts_int) <= timedelta(days=1):
                         time_string = " at {time}"


### PR DESCRIPTION
The Slack documentation claims that the “ts” flag on attachments is “An integer Unix timestamp”. However, evidently it can be in milliseconds (i.e., a timestamp multiplied by 1000), causing out-of-range exceptions when trying to feed them to date.fromtimestamp(). This can cause all messages after such attachments to just vanish, as if they were never there, as parsing stops.

Accept both; as a heuristic, the Slack web interface seems to use 100000000000 as a threshold, so we do the same and divide by 1000 if so.