### PR TITLE
Add `/slack reload_auth` to refresh auth tokens without reloading the whole script

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1674,6 +1674,9 @@ class SlackTeam(object):
     def generate_usergroup_map(self):
         return {s.handle: s.identifier for s in self.subteams.values()}
 
+    def set_token(self, token):
+        self.token = token
+
     def set_name(self):
         alias = config.server_aliases.get(self.subdomain)
         if alias:
@@ -6341,6 +6344,53 @@ def command_away(data, current_buffer, args):
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
     s = SlackRequest(team, "users.setPresence", {"presence": "away"})
     EVENTROUTER.receive(s)
+    return w.WEECHAT_RC_OK
+
+
+@slack_buffer_required
+@utf8_decode
+def command_reload_auth(data, current_buffer, args):
+    """
+    /slack reload_auth [<n>]
+    Re-reads the slack auth token from weechat config, for the team of the current buffer.
+    <n> specifies which entry the token is in the config string (when there's more than 1),
+    zero-indexed, and defaults to 0.
+    """
+    team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
+    n = 0
+    if args:
+        try:
+            n = int(args)
+        except ValueError:
+            w.prnt(
+                "",
+                "Error: argument must be integer (defaults to 0 if absent): '{}'".format(args),
+            )
+            return w.WEECHAT_RC_OK_EAT
+
+    # Force the token value to be re-read from weechat config
+    config.config_changed(None, CONFIG_PREFIX + ".slack_api_token", None)
+    tokens = [
+        token.strip()
+        for token in config.slack_api_token.split(",")
+        if token
+    ]
+    t = tokens[n]
+    if t.startswith("xoxc-") and ":" not in t:
+        w.prnt(
+            "",
+            "{}When using an xoxc token, you need to also provide the d cookie in the format token:cookie".format(
+                w.prefix("error")
+            ),
+        )
+        return w.WEECHAT_RC_OK_EAT
+
+    w.prnt(
+        "",
+        "Reloading auth token with index {} ({}) and applying to team with subdomain {} (prev token {}).".format(n, token_for_print(t), team.subdomain, token_for_print(team.token)),
+    )
+
+    team.set_token(t)
     return w.WEECHAT_RC_OK
 
 


### PR DESCRIPTION
Large orgs can take a long time for wee-slack to (re)load (eg. 1 hour).  If the session auth length is also short (eg. 1 week or less), then having to fully restart wee-slack that often gets pretty disruptive (having to get the session token out of the browser is bad enough).

This patch adds a command that simply re-reads the token config from weechat, and then plumbs the new value into the SlackTeam object.  Thus when your session token has expired, and you are getting lots of `invalid_auth` errors in the wee-slack console, you can do

```
/set plugins.var.python.slack.slack_api_token <newtoken>
/slack reload_auth
```
or
```
/secure set slack_token <newtoken>
/slack reload_auth
```
and then the currently running wee-slack script will be able to auth successfully on the next attempt, no `/python reload slack` required.

If you're in multiple teams, then a little more care is needed, you have to update the token list in the weechat config carefully, and note the index of which one has changed (zero-based).  Then, from a weechat buffer in that team, do
```
/slack reload_auth <n>
```
where `<n>` is the index number of the appropriate entry in the token string.

Thoughts?  The interface around multiple teams and specifying `<n>` is a little clunky, and could probably be better, but I wanted to check that the approach even works in the first place (it seems to work ok for me), and I figure someone more familiar with wee-slack would have a better idea of how/if this aspect could be improved.  But this seems like a decent base to start from, at the very least.