### PR TITLE
Increase retry time to avoid crashing on fork issues

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1479,7 +1479,7 @@ class SlackRequest(object):
         self.channel = channel
         self.metadata = metadata if metadata else {}
         self.retries = retries
-        self.retry_time = 0
+        self.retry_time = 1000
         self.token = token if token else team.token
         self.cookies = cookies or {}
         if ":" in self.token:


### PR DESCRIPTION
Started `weechat -s`
and done `/script load wee_slack.py`
after around 5 minutes trying to connect, the logs started showing:

```
2024-01-12 21:20:52             Failed requesting conversations.info for team domain=test nick=ricardo.amaro, retrying. If this persists, try increasing slack_timeout. Error (code -2): fork error: Cannot allocate memory
2024-01-12 21:20:52             Failed requesting conversations.info for team domain=test nick=ricardo.amaro, retrying. If this persists, try increasing slack_timeout. Error (code -2): 
2024-01-12 21:20:52             *** Very bad! WeeChat is crashing (SIGSEGV received)
2024-01-12 21:20:52             *** Full crash dump was saved to /home/ricardo/.weechat/weechat_crash_20240112_3256301.log file.
2024-01-12 21:20:52             ***
2024-01-12 21:20:52             *** Please help WeeChat developers to fix this bug:
2024-01-12 21:20:52             ***
2024-01-12 21:20:52             ***   1. If you have a core file, please run: gdb /path/to/weechat core
2024-01-12 21:20:52             ***      then issue command: "bt full" and send result to developers.
2024-01-12 21:20:52             ***      See the user's guide for more info about enabling the core files
2024-01-12 21:20:52             ***      and reporting crashes:
2024-01-12 21:20:52             ***      https://weechat.org/doc/weechat/stable/user/#report_crashes
2024-01-12 21:20:52             ***
2024-01-12 21:20:52             ***   2. Otherwise send the backtrace (below), only if it is a complete trace.
2024-01-12 21:20:52             ***      Keep the crash log file, just in case developers ask you some info
2024-01-12 21:20:52             ***      (be careful, private info like passwords may be in this file).
2024-01-12 21:20:52             
2024-01-12 21:20:52             ======= WeeChat backtrace =======
2024-01-12 21:20:52             (written by WeeChat 4.1.2, compiled on Dec  7 2023 09:06:21)
2024-01-12 21:20:52             001  ??:0 [function ??]
2024-01-12 21:20:52             002  ??:0 [function ??]
2024-01-12 21:20:52             addr2line: '0xa53b1': No such file
2024-01-12 21:20:52             addr2line: '0x1a88ed': No such file
2024-01-12 21:20:52             005  ??:? [function __restore_rt]
2024-01-12 21:20:52             addr2line: '0xd197': No such file
2024-01-12 21:20:52             addr2line: '0xd4fd': No such file
2024-01-12 21:20:52             addr2line: '0xdc33e': No such file
2024-01-12 21:20:52             addr2line: '0xe1a88': No such file
2024-01-12 21:20:52             addr2line: '0xe1d90': No such file
2024-01-12 21:20:52             addr2line: '0xeb32a': No such file
2024-01-12 21:20:52             addr2line: '0xeb7e2': No such file
2024-01-12 21:20:52             addr2line: '0xebab5': No such file
2024-01-12 21:20:52             addr2line: '0xebaff': No such file
2024-01-12 21:20:52             addr2line: '0x6a28e': No such file
2024-01-12 21:20:52             addr2line: '0x67885': No such file
2024-01-12 21:20:52             addr2line: '0x69abf': No such file
2024-01-12 21:20:52             addr2line: '0x15426': No such file
2024-01-12 21:20:52             addr2line: '0x16f23': No such file
2024-01-12 21:20:52             addr2line: '0x37e8d': No such file
2024-01-12 21:20:52             addr2line: '0x38f19': No such file
2024-01-12 21:20:52             addr2line: '0x2f513': No such file
2024-01-12 21:20:52             023  ??:0 [function ??]
2024-01-12 21:20:52             024  ??:0 [function ??]
2024-01-12 21:20:52             025  ??:0 [function ??]
2024-01-12 21:20:52             026  ??:0 [function ??]
2024-01-12 21:20:52             addr2line: '0x2ad5c': No such file
2024-01-12 21:20:52             addr2line: '0x2330b': No such file
2024-01-12 21:20:52             addr2line: '0x2a8697': No such file
2024-01-12 21:20:52             addr2line: '0x7df48': No such file
2024-01-12 21:20:52             addr2line: '0x1cae4b': No such file
2024-01-12 21:20:52             addr2line: '0x2a8124': No such file
2024-01-12 21:20:52             addr2line: '0x74d6d': No such file
2024-01-12 21:20:52             addr2line: '0x7cef6': No such file
2024-01-12 21:20:52             addr2line: '0x8006b': No such file
2024-01-12 21:20:52             addr2line: '0x74d6d': No such file
2024-01-12 21:20:52             addr2line: '0x7646d': No such file
2024-01-12 21:20:52             addr2line: '0x8006b': No such file
2024-01-12 21:20:52             addr2line: '0x74d6d': No such file
2024-01-12 21:20:52             addr2line: '0x76018': No such file
2024-01-12 21:20:52             addr2line: '0x8006b': No such file
2024-01-12 21:20:52             addr2line: '0x2a8f23': No such file
2024-01-12 21:20:52             addr2line: '0x2aa18f': No such file
2024-01-12 21:20:52             addr2line: '0x9993': No such file
2024-01-12 21:20:52             addr2line: '0xc16e': No such file
2024-01-12 21:20:52             046  ??:0 [function ??]
2024-01-12 21:20:52             047  ??:0 [function ??]
2024-01-12 21:20:52             048  ??:0 [function ??]
2024-01-12 21:20:52             049  ??:? [function __libc_start_main]
2024-01-12 21:20:52             050  ??:0 [function ??]
2024-01-12 21:20:52             ======= End of  backtrace =======
2024-01-12 21:20:52             Failed requesting conversations.info for team domain=test nick=ricardo.amaro, retrying. If this persists, try increasing slack_timeout. Error (code 0): ratelimited
```
There is probably a better way to fix this, but in my case it has reduced the errors during startup.