### PR TITLE
Set user user presence

### DIFF
--- a/slack/commands.py
+++ b/slack/commands.py
@@ -287,6 +287,20 @@ def command_slack_reply(buffer: str, args: List[str], options: Options):
         run_async(slack_buffer.post_message(split_args[1], thread_ts, broadcast))
 
 
+@weechat_command("away|active")
+def command_slack_presence(buffer: str, args: List[str], options: Options):
+    slack_buffer = shared.buffers.get(buffer)
+    if slack_buffer is None:
+        return
+    new_presence = args[0]
+    if new_presence not in ("active", "away"):
+        print_error(
+            f'Error with command "/slack presence {args[0]}" (help on command: /help slack presence)'
+        )
+        return
+    run_async(slack_buffer.workspace.api.set_presence(new_presence))
+
+
 def print_uncaught_error(error: UncaughtError, detailed: bool, options: Options):
     weechat.prnt("", f"  {error.id} ({error.time}): {error.exception}")
     if detailed:

--- a/slack/slack_api.py
+++ b/slack/slack_api.py
@@ -412,3 +412,11 @@ class SlackApi(SlackApiCommon):
         if response["ok"] is False:
             raise SlackApiError(self.workspace, method, response, params)
         return response
+
+    async def set_presence(self, presence: Literal["active", "away"]):
+        method = "presence.set"
+        params: Params = {"presence": presence}
+        response: SlackGenericResponse = await self._fetch(method, params)
+        if response["ok"] is False:
+            raise SlackApiError(self.workspace, method, response, params)
+        return response


### PR DESCRIPTION
The user can now set his presence with:

/slack away

and back with:

/slack back

It's not possible to set a custom status for now.