### PR TITLE
feat: Filter users list based on regular expression

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -240,8 +240,9 @@ If handle is given show the members in the usergroup
 ### users
 
 ```
-/slack users
+/slack users [regex]
 ```
 
 List the users in the current team.
+If regex is given show only users that match the case-insensitive regex.
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -5736,11 +5736,21 @@ def command_channels(data, current_buffer, args):
 @utf8_decode
 def command_users(data, current_buffer, args):
     """
-    /slack users
+    /slack users [regex]
     List the users in the current team.
+    If regex is given show only users that match the case-insensitive regex.
     """
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
-    return print_users_info(team, "Users", team.users.values())
+    pat = re.compile(args, flags=re.IGNORECASE)
+
+    if pat is None:
+        users = team.users.values()
+        header = "Users"
+    else:
+        users = [v for v in team.users.values() if pat.search(v.name)]
+        header = 'Users that match "{}"'.format(args)
+
+    return print_users_info(team, header, users)
 
 
 @slack_buffer_required

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -5741,14 +5741,14 @@ def command_users(data, current_buffer, args):
     If regex is given show only users that match the case-insensitive regex.
     """
     team = EVENTROUTER.weechat_controller.buffers[current_buffer].team
-    pat = re.compile(args, flags=re.IGNORECASE)
 
-    if pat is None:
-        users = team.users.values()
-        header = "Users"
-    else:
+    if args:
+        pat = re.compile(args, flags=re.IGNORECASE)
         users = [v for v in team.users.values() if pat.search(v.name)]
         header = 'Users that match "{}"'.format(args)
+    else:
+        users = team.users.values()
+        header = "Users"
 
     return print_users_info(team, header, users)
 


### PR DESCRIPTION
It can be difficult to find a specific user when there are tens of thousands of users in your slack team.  This enhancement allows you to filter users based on a case-insensitive regular expression.  For example:

```
/slack users ^.Mason

Users that match "^.Mason"

    bmason  (active)
    jmason  (inactive)
    lmason (active)
    SMason  (inactive)
```