### PR TITLE
conversation: show user real name in title

### DIFF
--- a/slack/slack_conversation.py
+++ b/slack/slack_conversation.py
@@ -343,7 +343,8 @@ class SlackConversation(SlackBuffer):
         topic = unhtmlescape(self._topic["value"])
         if self._im_user:
             status = f"{self._im_user.status_emoji} {self._im_user.status_text}".strip()
-            return " | ".join(part for part in [status, topic] if part)
+            parts = [self._im_user.real_name, status, topic]
+            return " | ".join(part for part in parts if part)
         return topic
 
     def set_topic(self, title: str):

--- a/slack/slack_user.py
+++ b/slack/slack_user.py
@@ -126,6 +126,12 @@ class SlackUser:
         return get_emoji(status_emoji.strip(":"))
 
     @property
+    def real_name(self) -> str:
+        return self._info["profile"].get("real_name") or name_from_user_info(
+            self.workspace, self._info
+        )
+
+    @property
     def nick(self) -> Nick:
         nick = name_from_user_info(self.workspace, self._info)
         return get_user_nick(nick, self.is_external, self.is_self)


### PR DESCRIPTION
When opening a private conversation, show the real name of the user in the status bar instead of an empty status.