### PR TITLE
message: use nick color for user mentions

### DIFF
--- a/slack/slack_message.py
+++ b/slack/slack_message.py
@@ -271,7 +271,9 @@ class PendingMessageItem:
 
             if self.display_type == "mention":
                 name = f"@{user.nick.format()}"
-                return with_color(shared.config.color.user_mention.value, name)
+                return with_color(
+                    user.nick.color or shared.config.color.user_mention.value, name
+                )
             elif self.display_type == "chat":
                 return user.nick.format(colorize=True)
             else:


### PR DESCRIPTION
Instead of using the same color for all user mentions, reuse the mentioned user nick color.