### PR TITLE
s/ command: fix deprecation warning about positional args in re.sub

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2060,7 +2060,9 @@ class SlackChannelCommon(object):
             f |= re.MULTILINE if "m" in flags else 0
             f |= re.DOTALL if "s" in flags else 0
             old_message_text = message.message_json["text"]
-            new_message_text = re.sub(old, new, old_message_text, num_replace, f)
+            new_message_text = re.sub(
+                old, new, old_message_text, count=num_replace, flags=f
+            )
             if new_message_text != old_message_text:
                 post_data = {
                     "channel": self.identifier,


### PR DESCRIPTION
In newer Python versions, using count/flags on re.sub in positional mode triggers a `DeprecationWarning`:

```
python: stdout/stderr (slack): ~/.weechat/python/autoload/wee_slack.py:2063:
        DeprecationWarning: 'count' is passed as positional argument
python: stdout/stderr (slack):   new_message_text = re.sub(old, new, old_message_text, num_replace, f)
```

This commit changes the call to use flags and count in keyword argument mode.