### PR TITLE
feat: added virual buffers to simulate channel sections

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -34,6 +34,12 @@ slack` after changing it to take effect.
 
 **Description:** Change the prefix of a channel from # to > when someone is typing in it. Note that this will (temporarily) affect the sort order if you sort buffers by name rather than by number.
 
+### channel_section_buffer
+
+**Default:** `false`
+
+**Description**: Enable to create virtual buffers for sorting channels using channel sections. Use autosort.py for better sorting.
+
 ### color_buflist_muted_channels
 
 **Default:** `darkgray`


### PR DESCRIPTION
# Context

The purpose of this PR is to support viewing custom sections in wee_slack. Currently, that I am aware of, to properly sort a buffer in groups. There was dicussion about this in another plugin while researching a solution (see [post](https://github.com/poljar/weechat-matrix/issues/34#issuecomment-457904834)). So I used virtual buffers to simulate channel sections. If there is a better approach I will gladly accept any other solutions.

Custom sections are only supported on paid plans. For me it is definitely helpful when working with many channels.

# Testing
1. Enable the `channel_section_buffer` setting: 
```
 /set plugins.var.python.slack.channel_section_buffer "true" 
```
2. Reload wee_slack
```
/python load slack
```
3. Enable autosort
```
/autosort
```

> [!NOTE]
> - There doesn't appear to be a public API to manage custom sections such as moving channels into sections or creating new ones. If there is one I can add the implementation in. As for as I looked there isn't one. I can reverse engineering how it is done via the web/electron app but I would rather not since that can be subject to change.
> - You will need to have the `autosort.py` enabled in order to get proper sorting. The full buffer name is used for sorting. Make sure to have `${buffer.full_name}` as rule. See attached image below for example.

# Screenshots

**Slack with sections collapsed**
<img width="412" height="688" alt="slack_web_collapse" src="https://github.com/user-attachments/assets/124cf0c1-bd42-4ff7-be92-bc5bee94a843" />


**Slack with sections uncollapsed**
<img width="373" height="367" alt="slack_web_uncollapse" src="https://github.com/user-attachments/assets/3de141a8-a855-4166-af6c-af8347b871d7" />


**Disabled channel section sorting on weeslack**
<img width="242" height="552" alt="wee_slack_unsorted" src="https://github.com/user-attachments/assets/8cd5bbf9-f5be-4d1f-b508-b863da4d24cd" />


**Enabled channel section sorting on weeslack**
<img width="196" height="328" alt="wee_slack_sorted" src="https://github.com/user-attachments/assets/68b64a8e-c0e7-42d4-a61d-cd9e7b69fbac" />


**Autosort rules**
<img width="1007" height="323" alt="image" src="https://github.com/user-attachments/assets/2b2324c3-c1fc-4568-ba6e-9d733909d551" />

<img width="1560" height="375" alt="image" src="https://github.com/user-attachments/assets/80cedd6c-284e-4086-b3dc-3599d03802ad" />


Resolves https://github.com/wee-slack/wee-slack/issues/817
