### PR TITLE
workspace: fix key error when listing muted channels

### DIFF
--- a/slack/slack_workspace.py
+++ b/slack/slack_workspace.py
@@ -423,7 +423,7 @@ class SlackWorkspace(SlackBuffer):
             new_muted_channels = set(
                 channel_id
                 for channel_id, prefs in channels_prefs.items()
-                if prefs["muted"]
+                if prefs.get("muted")
             )
             self._set_muted_channels(new_muted_channels)
         else:


### PR DESCRIPTION
Fix the following error on connect:

    Traceback (most recent call last):
      File "slack/task.py", line 205, in task_runner
      future = task.coroutine.send(None)
    StopIteration: <slack.slack_user.SlackUser object at 0x7f5292a1b410>

During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "slack/slack_workspace.py", line 570, in _initialize
      conversations_to_open = await self._initialize_session()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "slack/slack_workspace.py", line 498, in _initialize_session
      self._set_all_notification_prefs(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
          user_boot["prefs"].get("all_notifications_prefs", "")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
      File "slack/slack_workspace.py", line 423, in _set_all_notification_prefs
      new_muted_channels = set(
          channel_id
          for channel_id, prefs in channels_prefs.items()
          if prefs["muted"]
      )
      File "slack/slack_workspace.py", line 426, in <genexpr>
      if prefs["muted"]
         ~~~~~^^^^^^^^^
    KeyError: 'muted'

Apparently, not all channel prefs have the "muted" attribute set.

Closes: https://github.com/wee-slack/wee-slack/issues/964