### PR TITLE
slack_workspace: handle channel and group rename events

### DIFF
--- a/slack/slack_conversation.py
+++ b/slack/slack_conversation.py
@@ -347,6 +347,10 @@ class SlackConversation(SlackMessageBuffer):
             return " | ".join(part for part in parts if part)
         return topic
 
+    def set_name(self, name: str):
+        self._info["name"] = name  # pyright: ignore [reportGeneralTypeIssues]
+        self.update_buffer_props()
+
     def set_topic(self, title: str):
         self._topic["value"] = title
         self.update_buffer_props()

--- a/slack/slack_workspace.py
+++ b/slack/slack_workspace.py
@@ -747,6 +747,8 @@ class SlackWorkspace(SlackBuffer):
                 return
             elif data["type"] == "channel_joined" or data["type"] == "group_joined":
                 channel_id = data["channel"]["id"]
+            elif data["type"] == "channel_rename" or data["type"] == "group_rename":
+                channel_id = data["channel"]["id"]
             elif data["type"] == "reaction_added" or data["type"] == "reaction_removed":
                 channel_id = data["item"]["channel"]
             elif (
@@ -859,6 +861,8 @@ class SlackWorkspace(SlackBuffer):
                     await message.update_subscribed(subscribed, data["subscription"])
             elif data["type"] == "sh_room_join" or data["type"] == "sh_room_update":
                 await channel.update_message_room(data)
+            elif data["type"] == "channel_rename" or data["type"] == "group_rename":
+                channel.set_name(str(data["channel"]["name"]))
             elif data["type"] == "user_typing":
                 await channel.typing_add_user(data)
             else:

--- a/typings/slack_rtm/slack_rtm_message.pyi
+++ b/typings/slack_rtm/slack_rtm_message.pyi
@@ -378,6 +378,15 @@ class SlackEmojiChangedRemove(TypedDict):
     names: List[str]
     event_ts: str
 
+class SlackChannelRenameChannel(TypedDict):
+    id: str
+    name: str
+
+@final
+class SlackChannelRename(TypedDict):
+    type: Literal["channel_rename", "group_rename"]
+    channel: SlackChannelRenameChannel
+
 SlackMessageRtm = (
     SlackMessageStandardRtm
     | SlackMessageMeRtm
@@ -431,4 +440,5 @@ SlackRtmMessage = (
     | SlackSubteamSelfRemoved
     | SlackEmojiChangedAdd
     | SlackEmojiChangedRemove
+    | SlackChannelRename
 )


### PR DESCRIPTION
When a channel or group is renamed on the server, update the cached conversation info and refresh the WeeChat buffer properties so the new name is reflected immediately.

Closes: https://github.com/wee-slack/wee-slack/issues/940